### PR TITLE
Update insp_config to build without errors

### DIFF
--- a/insp_config
+++ b/insp_config
@@ -42,6 +42,9 @@ CONFIG_TARGET_ramips=y
 # CONFIG_TARGET_uml is not set
 # CONFIG_TARGET_zynq is not set
 # CONFIG_TARGET_x86 is not set
+# CONFIG_TARGET_ath79_generic is not set
+# CONFIG_TARGET_ath79_nand is not set
+# CONFIG_TARGET_ath79_tiny is not set
 # CONFIG_TARGET_ramips_mt7620 is not set
 # CONFIG_TARGET_ramips_mt7621 is not set
 CONFIG_TARGET_ramips_mt76x8=y
@@ -49,6 +52,221 @@ CONFIG_TARGET_ramips_mt76x8=y
 # CONFIG_TARGET_ramips_rt305x is not set
 # CONFIG_TARGET_ramips_rt3883 is not set
 # CONFIG_TARGET_MULTI_PROFILE is not set
+# CONFIG_TARGET_ath79_generic_Default is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_8dev_carambola2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_avm_fritz4020 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_avm_fritz300e is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_aruba_ap-105 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_buffalo_bhr-4grv is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_buffalo_bhr-4grv2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_buffalo_wzr-hp-ag300h is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_buffalo_wzr-hp-g302h-a1a0 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_buffalo_wzr-hp-g450h is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_comfast_cf-e110n-v2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_comfast_cf-e120a-v3 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_comfast_cf-e5 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_dlink_dir-825-b1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_dlink_dir-825-c1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_dlink_dir-835-a1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_dlink_dir-859-a1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_elecom_wrc-1750ghbk2-i is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_elecom_wrc-300ghbk2-i is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_embeddedwireless_dorin is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_engenius_ecb1750 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_engenius_epg5000 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_engenius_ews511ap is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_glinet_gl-ar150 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_glinet_gl-ar300m-lite is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_glinet_gl-x750 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_iodata_etg3-r is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_iodata_wn-ac1167dgr is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_iodata_wn-ac1600dgr is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_iodata_wn-ac1600dgr2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_iodata_wn-ag300dgr is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_librerouter_librerouter-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_nec_wg1200cr is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_nec_wg800hp is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_netgear_ex6400 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_netgear_ex7300 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_netgear_wndr3700 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_netgear_wndr3700v2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_netgear_wndr3800 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ocedo_koala is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ocedo_raccoon is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ocedo_ursus is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_openmesh_om5p-ac-v2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_phicomm_k2t is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_pisen_wmm003n is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_pcs_cap324 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_pcs_cr3000 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_pcs_cr5000 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_rosinson_wr818 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-a7-v5 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-c2-v3 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-c25-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-c5-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-c58-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-c59-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-c6-v2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-c60-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-c60-v2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-c60-v3 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-c7-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-c7-v2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-c7-v4 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-c7-v5 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_archer-d50-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_cpe210-v2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_cpe210-v3 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_cpe220-v3 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_re350k-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_re450-v2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wdr3500-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wdr3600-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wdr4300-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wdr4300-v1-il is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wdr4310-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wdr4900-v2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wr1043n-v5 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wr1043nd-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wr1043nd-v2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wr1043nd-v3 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wr1043nd-v4 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wr2543-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wr710n-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wr710n-v2.1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wr810n-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wr810n-v2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wr842n-v3 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wr842n-v1 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_tplink_tl-wr842n-v2 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_airrouter is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_bullet-m is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_bullet-m-xw is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_lap-120 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_nanobeam-ac is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_nanostation-ac is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_nanostation-ac-loco is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_nanostation-loco-m is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_nanostation-loco-m-xw is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_nanostation-m is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_nanostation-m-xw is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_picostation-m is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_rocket-m is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_routerstation is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_routerstation-pro is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_unifi is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_unifiac-lr is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_unifiac-lite is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_unifiac-mesh is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_unifiac-mesh-pro is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_unifiac-pro is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_ubnt_acb-isp is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_wd_mynet-n750 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_wd_mynet-wifi-rangeextender is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_winchannel_wb2000 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_xiaomi_mi-router-4q is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_yuncore_a770 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_yuncore_a782 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_yuncore_xd4200 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_zbtlink_zbt-wd323 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_devolo_dvl1200e is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_devolo_dvl1200i is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_devolo_dvl1750c is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_devolo_dvl1750e is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_devolo_dvl1750i is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_devolo_dvl1750x is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_etactica_eg200 is not set
+# CONFIG_TARGET_ath79_generic_DEVICE_jjplus_ja76pf2 is not set
+# CONFIG_TARGET_ramips_mt7620_Default is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_alfa-network_ac1200rm is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_alfa-network_r36m-e4g is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_alfa-network_tube-e4g is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_ai-br100 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_rp-n53 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_rt-ac51u is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_rt-n12p is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_rt-n14u is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_bdcom_wap2100-sk is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_whr-1166d is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_whr-300hp2 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_whr-600d is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_wmr-300 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_cf-wr800n is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_dch-m225 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_dlink_dir-510l is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_dir-810l is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_dlink_dwr-116-a1 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_dlink_dwr-118-a1 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_dlink_dwr-118-a2 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_dlink_dwr-921-c1 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_dlink_dwr-921-c3 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_dlink_dwr-922-e2 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_tiny-ac is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_edimax_br-6478ac-v2 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_wrh-300cr is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_gl-mt300a is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_gl-mt300n is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_gl-mt750 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_c108 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_head-weblink_hdrm200 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_hc5661 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_hc5761 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_hc5861 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_iodata_wn-ac1167gr is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_iodata_wn-ac733gr3 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_u25awf-h1 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_kimax_u35wf is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_mlw221 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_mlwg2 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_lava_lr-25g001 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_y1 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_y1s is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_e1700 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_mt7620a_mt7530 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_mt7620a_mt7610e is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_mt7620a is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_mt7620a_v22sg is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_microwrt is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_ex3700-ex3800 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_wn3000rpv3 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_wt3020-8M is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_oy-0001 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_phicomm_k2g is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_psg1208 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_psg1218a is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_psg1218b is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_cs-qr10 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_db-wrt01 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_mzk-750dhp is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_mzk-ex300np is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_mzk-ex750np is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_ravpower_wd03 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_d240 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_na930 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_tplink_c2-v1 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_tplink_c20-v1 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_ArcherC20i is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_ArcherC50v1 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_ArcherMR200 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_vonets_var11n-300 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_wrtnode is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_miwifi-mini is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_youku-yk1 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_bocco is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_zte-q7 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_zbt-ape522ii is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_zbt-cpe102 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_zbt-wa05 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_we1026-5g-16m is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_zbt-we2026 is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_zbt-we826-16M is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_zbt-we826-32M is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_zbtlink_zbt-we826-e is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_zbt-wr8305rt is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_kn_rc is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_kn_rf is not set
+# CONFIG_TARGET_ramips_mt7620_DEVICE_kng_rc is not set
 # CONFIG_TARGET_ramips_mt76x8_Default is not set
 # CONFIG_TARGET_ramips_mt76x8_DEVICE_alfa-network_awusfree1 is not set
 # CONFIG_TARGET_ramips_mt76x8_DEVICE_wcr-1166ds is not set
@@ -187,7 +405,7 @@ CONFIG_SIGNATURE_CHECK=y
 #
 # General build options
 #
-# CONFIG_DISPLAY_SUPPORT is not set
+CONFIG_DISPLAY_SUPPORT=y
 # CONFIG_BUILD_PATENTED is not set
 # CONFIG_BUILD_NLS is not set
 CONFIG_SHADOW_PASSWORDS=y
@@ -360,21 +578,18 @@ CONFIG_TARGET_INIT_CMD="/sbin/init"
 CONFIG_TARGET_INIT_SUPPRESS_STDERR=y
 # CONFIG_VERSIONOPT is not set
 CONFIG_PER_FEED_REPO=y
-CONFIG_FEED_packages=y
-CONFIG_FEED_luci=y
-CONFIG_FEED_routing=y
-CONFIG_FEED_telephony=y
-CONFIG_FEED_freifunk=y
+# CONFIG_FEED_packages is not set
+# CONFIG_FEED_luci is not set
+# CONFIG_FEED_routing is not set
+# CONFIG_FEED_telephony is not set
+# CONFIG_FEED_freifunk is not set
 
 #
 # Base system
 #
-# CONFIG_PACKAGE_attendedsysupgrade-common is not set
-# CONFIG_PACKAGE_auc is not set
 CONFIG_PACKAGE_base-files=y
 # CONFIG_PACKAGE_block-mount is not set
 # CONFIG_PACKAGE_blockd is not set
-# CONFIG_PACKAGE_bridge is not set
 CONFIG_PACKAGE_busybox=y
 # CONFIG_BUSYBOX_CUSTOM is not set
 CONFIG_BUSYBOX_DEFAULT_HAVE_DOT_CONFIG=y
@@ -1440,12 +1655,11 @@ CONFIG_PACKAGE_libc=y
 CONFIG_PACKAGE_libgcc=y
 # CONFIG_PACKAGE_libgomp is not set
 CONFIG_PACKAGE_libpthread=y
-# CONFIG_PACKAGE_librt is not set
-# CONFIG_PACKAGE_libstdcpp is not set
+CONFIG_PACKAGE_librt=y
+CONFIG_PACKAGE_libstdcpp=y
 CONFIG_PACKAGE_logd=y
 CONFIG_PACKAGE_mtd=y
 CONFIG_PACKAGE_netifd=y
-# CONFIG_PACKAGE_nft-qos is not set
 # CONFIG_PACKAGE_om-watchdog is not set
 CONFIG_PACKAGE_openwrt-keyring=y
 CONFIG_PACKAGE_opkg=y
@@ -1460,8 +1674,6 @@ CONFIG_PACKAGE_procd=y
 # CONFIG_PACKAGE_resolveip is not set
 # CONFIG_PACKAGE_rpcd is not set
 # CONFIG_PACKAGE_snapshot-tool is not set
-# CONFIG_PACKAGE_sqm-scripts is not set
-# CONFIG_PACKAGE_sqm-scripts-extra is not set
 CONFIG_PACKAGE_swconfig=y
 CONFIG_PACKAGE_ubox=y
 CONFIG_PACKAGE_ubus=y
@@ -1476,56 +1688,6 @@ CONFIG_PACKAGE_usign=y
 # CONFIG_PACKAGE_zram-swap is not set
 
 #
-# Administration
-#
-
-#
-# openwisp
-#
-# CONFIG_PACKAGE_openwisp-config-mbedtls is not set
-# CONFIG_PACKAGE_openwisp-config-nossl is not set
-# CONFIG_PACKAGE_openwisp-config-openssl is not set
-# CONFIG_PACKAGE_openwisp-config-wolfssl is not set
-
-#
-# zabbix
-#
-# CONFIG_PACKAGE_zabbix-agentd is not set
-
-#
-# SSL support
-#
-# CONFIG_ZABBIX_OPENSSL is not set
-# CONFIG_ZABBIX_GNUTLS is not set
-CONFIG_ZABBIX_NOSSL=y
-# CONFIG_PACKAGE_zabbix-extra-mac80211 is not set
-# CONFIG_PACKAGE_zabbix-extra-network is not set
-# CONFIG_PACKAGE_zabbix-extra-wifi is not set
-# CONFIG_PACKAGE_zabbix-get is not set
-# CONFIG_PACKAGE_zabbix-proxy is not set
-# CONFIG_PACKAGE_zabbix-sender is not set
-# CONFIG_PACKAGE_zabbix-server is not set
-
-#
-# Database Software
-#
-# CONFIG_ZABBIX_MYSQL is not set
-CONFIG_ZABBIX_POSTGRESQL=y
-# CONFIG_PACKAGE_zabbix-server-frontend is not set
-# CONFIG_PACKAGE_atop is not set
-# CONFIG_PACKAGE_debootstrap is not set
-# CONFIG_PACKAGE_gkrellmd is not set
-# CONFIG_PACKAGE_htop is not set
-# CONFIG_PACKAGE_ipmitool is not set
-# CONFIG_PACKAGE_monit is not set
-# CONFIG_PACKAGE_monit-nossl is not set
-# CONFIG_PACKAGE_muninlite is not set
-# CONFIG_PACKAGE_netatop is not set
-# CONFIG_PACKAGE_netdata is not set
-# CONFIG_PACKAGE_sudo is not set
-# CONFIG_PACKAGE_syslog-ng is not set
-
-#
 # Boot Loaders
 #
 
@@ -1536,35 +1698,16 @@ CONFIG_ZABBIX_POSTGRESQL=y
 #
 # Libraries
 #
+# CONFIG_PACKAGE_libncurses-dev is not set
+# CONFIG_PACKAGE_zlib-dev is not set
 # CONFIG_PACKAGE_ar is not set
-# CONFIG_PACKAGE_autoconf is not set
-# CONFIG_PACKAGE_automake is not set
 # CONFIG_PACKAGE_binutils is not set
-# CONFIG_PACKAGE_diffutils is not set
-# CONFIG_PACKAGE_gcc is not set
 # CONFIG_PACKAGE_gdb is not set
 # CONFIG_PACKAGE_gdbserver is not set
-# CONFIG_PACKAGE_libtool-bin is not set
-# CONFIG_PACKAGE_lpc21isp is not set
-# CONFIG_PACKAGE_lttng-tools is not set
-# CONFIG_PACKAGE_m4 is not set
-# CONFIG_PACKAGE_make is not set
-# CONFIG_PACKAGE_meson is not set
-# CONFIG_PACKAGE_meson-src is not set
-# CONFIG_PACKAGE_ninja is not set
 # CONFIG_PACKAGE_objdump is not set
-# CONFIG_PACKAGE_patch is not set
-# CONFIG_PACKAGE_pkg-config is not set
 # CONFIG_PACKAGE_trace-cmd is not set
 # CONFIG_PACKAGE_trace-cmd-extra is not set
 # CONFIG_PACKAGE_valgrind is not set
-
-#
-# Extra packages
-#
-# CONFIG_PACKAGE_jose is not set
-# CONFIG_PACKAGE_libjose is not set
-# CONFIG_PACKAGE_tang is not set
 
 #
 # Firmware
@@ -1672,34 +1815,9 @@ CONFIG_PACKAGE_wireless-regdb=y
 # CONFIG_PACKAGE_wl18xx-firmware is not set
 
 #
-# Fonts
+# inspectron
 #
-
-#
-# DejaVu
-#
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuMathTeXGyre is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSans is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSans-Bold is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSans-BoldOblique is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSans-ExtraLight is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSans-Oblique is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSansCondensed is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSansCondensed-Bold is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSansCondensed-BoldOblique is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSansCondensed-Oblique is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSansMono is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSansMono-Bold is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSansMono-BoldOblique is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSansMono-Oblique is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSerif is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSerif-Bold is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSerif-BoldItalic is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSerif-Italic is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSerifCondensed is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSerifCondensed-Bold is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSerifCondensed-BoldItalic is not set
-# CONFIG_PACKAGE_dejavu-fonts-ttf-DejaVuSerifCondensed-Italic is not set
+# CONFIG_PACKAGE_wifiHandleController is not set
 
 #
 # Kernel modules
@@ -1783,7 +1901,6 @@ CONFIG_PACKAGE_wireless-regdb=y
 # CONFIG_PACKAGE_kmod-fs-cifs is not set
 # CONFIG_PACKAGE_kmod-fs-configfs is not set
 # CONFIG_PACKAGE_kmod-fs-cramfs is not set
-# CONFIG_PACKAGE_kmod-fs-exfat is not set
 # CONFIG_PACKAGE_kmod-fs-exportfs is not set
 # CONFIG_PACKAGE_kmod-fs-ext4 is not set
 # CONFIG_PACKAGE_kmod-fs-f2fs is not set
@@ -1792,7 +1909,6 @@ CONFIG_PACKAGE_wireless-regdb=y
 # CONFIG_PACKAGE_kmod-fs-hfsplus is not set
 # CONFIG_PACKAGE_kmod-fs-isofs is not set
 # CONFIG_PACKAGE_kmod-fs-jfs is not set
-# CONFIG_PACKAGE_kmod-fs-ksmbd is not set
 # CONFIG_PACKAGE_kmod-fs-minix is not set
 # CONFIG_PACKAGE_kmod-fs-msdos is not set
 # CONFIG_PACKAGE_kmod-fs-nfs is not set
@@ -1919,59 +2035,36 @@ CONFIG_PACKAGE_kmod-nls-base=y
 # CONFIG_PACKAGE_kmod-ebtables-watchers is not set
 CONFIG_PACKAGE_kmod-ip6tables=y
 # CONFIG_PACKAGE_kmod-ip6tables-extra is not set
-# CONFIG_PACKAGE_kmod-ipt-account is not set
-# CONFIG_PACKAGE_kmod-ipt-chaos is not set
 # CONFIG_PACKAGE_kmod-ipt-checksum is not set
 # CONFIG_PACKAGE_kmod-ipt-cluster is not set
 # CONFIG_PACKAGE_kmod-ipt-clusterip is not set
-# CONFIG_PACKAGE_kmod-ipt-compat-xtables is not set
-# CONFIG_PACKAGE_kmod-ipt-condition is not set
 CONFIG_PACKAGE_kmod-ipt-conntrack=y
 # CONFIG_PACKAGE_kmod-ipt-conntrack-extra is not set
 # CONFIG_PACKAGE_kmod-ipt-conntrack-label is not set
 CONFIG_PACKAGE_kmod-ipt-core=y
 # CONFIG_PACKAGE_kmod-ipt-debug is not set
-# CONFIG_PACKAGE_kmod-ipt-delude is not set
-# CONFIG_PACKAGE_kmod-ipt-dhcpmac is not set
-# CONFIG_PACKAGE_kmod-ipt-dnetmap is not set
 # CONFIG_PACKAGE_kmod-ipt-extra is not set
 # CONFIG_PACKAGE_kmod-ipt-filter is not set
-# CONFIG_PACKAGE_kmod-ipt-fuzzy is not set
-# CONFIG_PACKAGE_kmod-ipt-geoip is not set
 # CONFIG_PACKAGE_kmod-ipt-hashlimit is not set
-# CONFIG_PACKAGE_kmod-ipt-iface is not set
-# CONFIG_PACKAGE_kmod-ipt-ipmark is not set
 # CONFIG_PACKAGE_kmod-ipt-ipopt is not set
-# CONFIG_PACKAGE_kmod-ipt-ipp2p is not set
 # CONFIG_PACKAGE_kmod-ipt-iprange is not set
 # CONFIG_PACKAGE_kmod-ipt-ipsec is not set
 # CONFIG_PACKAGE_kmod-ipt-ipset is not set
-# CONFIG_PACKAGE_kmod-ipt-ipv4options is not set
 # CONFIG_PACKAGE_kmod-ipt-led is not set
-# CONFIG_PACKAGE_kmod-ipt-length2 is not set
-# CONFIG_PACKAGE_kmod-ipt-logmark is not set
-# CONFIG_PACKAGE_kmod-ipt-lscan is not set
-# CONFIG_PACKAGE_kmod-ipt-lua is not set
 CONFIG_PACKAGE_kmod-ipt-nat=y
 # CONFIG_PACKAGE_kmod-ipt-nat-extra is not set
 # CONFIG_PACKAGE_kmod-ipt-nat6 is not set
-# CONFIG_PACKAGE_kmod-ipt-nathelper-rtsp is not set
 # CONFIG_PACKAGE_kmod-ipt-nflog is not set
 # CONFIG_PACKAGE_kmod-ipt-nfqueue is not set
 CONFIG_PACKAGE_kmod-ipt-offload=y
 # CONFIG_PACKAGE_kmod-ipt-physdev is not set
-# CONFIG_PACKAGE_kmod-ipt-psd is not set
-# CONFIG_PACKAGE_kmod-ipt-quota2 is not set
 # CONFIG_PACKAGE_kmod-ipt-raw is not set
 # CONFIG_PACKAGE_kmod-ipt-raw6 is not set
 # CONFIG_PACKAGE_kmod-ipt-rpfilter is not set
-# CONFIG_PACKAGE_kmod-ipt-sysrq is not set
-# CONFIG_PACKAGE_kmod-ipt-tarpit is not set
 # CONFIG_PACKAGE_kmod-ipt-tee is not set
 # CONFIG_PACKAGE_kmod-ipt-tproxy is not set
 # CONFIG_PACKAGE_kmod-ipt-u32 is not set
 # CONFIG_PACKAGE_kmod-ipt-ulog is not set
-# CONFIG_PACKAGE_kmod-netatop is not set
 CONFIG_PACKAGE_kmod-nf-conntrack=y
 # CONFIG_PACKAGE_kmod-nf-conntrack-netlink is not set
 CONFIG_PACKAGE_kmod-nf-conntrack6=y
@@ -2037,7 +2130,6 @@ CONFIG_PACKAGE_kmod-nf-reject6=y
 # CONFIG_PACKAGE_kmod-phy-realtek is not set
 # CONFIG_PACKAGE_kmod-r6040 is not set
 # CONFIG_PACKAGE_kmod-r8169 is not set
-# CONFIG_PACKAGE_kmod-siit is not set
 # CONFIG_PACKAGE_kmod-sis190 is not set
 # CONFIG_PACKAGE_kmod-sis900 is not set
 # CONFIG_PACKAGE_kmod-skge is not set
@@ -2063,7 +2155,6 @@ CONFIG_PACKAGE_kmod-nf-reject6=y
 #
 # CONFIG_PACKAGE_kmod-atm is not set
 # CONFIG_PACKAGE_kmod-ax25 is not set
-# CONFIG_PACKAGE_kmod-batman-adv is not set
 # CONFIG_PACKAGE_kmod-bonding is not set
 # CONFIG_PACKAGE_kmod-bpf-test is not set
 # CONFIG_PACKAGE_kmod-capi is not set
@@ -2078,25 +2169,18 @@ CONFIG_PACKAGE_kmod-nf-reject6=y
 # CONFIG_PACKAGE_kmod-ipsec is not set
 # CONFIG_PACKAGE_kmod-iptunnel6 is not set
 # CONFIG_PACKAGE_kmod-isdn4linux is not set
-# CONFIG_PACKAGE_kmod-jool is not set
 # CONFIG_PACKAGE_kmod-l2tp is not set
 # CONFIG_PACKAGE_kmod-l2tp-eth is not set
 # CONFIG_PACKAGE_kmod-l2tp-ip is not set
-# CONFIG_PACKAGE_kmod-macremapper is not set
 # CONFIG_PACKAGE_kmod-macsec is not set
 # CONFIG_PACKAGE_kmod-misdn is not set
 # CONFIG_PACKAGE_kmod-mpls is not set
+CONFIG_PACKAGE_kmod-ppp=y
+# CONFIG_PACKAGE_kmod-mppe is not set
 # CONFIG_PACKAGE_kmod-nat46 is not set
 # CONFIG_PACKAGE_kmod-netem is not set
 # CONFIG_PACKAGE_kmod-nlmon is not set
-# CONFIG_PACKAGE_kmod-openvswitch is not set
-# CONFIG_PACKAGE_kmod-openvswitch-geneve is not set
-# CONFIG_PACKAGE_kmod-openvswitch-gre is not set
-# CONFIG_PACKAGE_kmod-openvswitch-vxlan is not set
-# CONFIG_PACKAGE_kmod-pf-ring is not set
 # CONFIG_PACKAGE_kmod-pktgen is not set
-CONFIG_PACKAGE_kmod-ppp=y
-# CONFIG_PACKAGE_kmod-mppe is not set
 # CONFIG_PACKAGE_kmod-ppp-synctty is not set
 # CONFIG_PACKAGE_kmod-pppoa is not set
 CONFIG_PACKAGE_kmod-pppoe=y
@@ -2154,7 +2238,6 @@ CONFIG_PACKAGE_kmod-gpio-button-hotplug=y
 # CONFIG_PACKAGE_kmod-itco-wdt is not set
 # CONFIG_PACKAGE_kmod-lp is not set
 CONFIG_PACKAGE_kmod-mmc=y
-# CONFIG_PACKAGE_kmod-mtd-rw is not set
 # CONFIG_PACKAGE_kmod-mtdoops is not set
 # CONFIG_PACKAGE_kmod-mtdram is not set
 # CONFIG_PACKAGE_kmod-mtdtests is not set
@@ -2186,7 +2269,6 @@ CONFIG_PACKAGE_kmod-sdhci-mt7620=y
 # CONFIG_PACKAGE_kmod-tpm-i2c-atmel is not set
 # CONFIG_PACKAGE_kmod-tpm-i2c-infineon is not set
 # CONFIG_PACKAGE_kmod-w83627hf-wdt is not set
-# CONFIG_PACKAGE_kmod-wifidog-ng is not set
 # CONFIG_PACKAGE_kmod-zram is not set
 
 #
@@ -2242,6 +2324,17 @@ CONFIG_PACKAGE_kmod-usb2=y
 #
 # Video Support
 #
+# CONFIG_PACKAGE_kmod-backlight-pwm is not set
+# CONFIG_PACKAGE_kmod-drm-kms-helper is not set
+# CONFIG_PACKAGE_kmod-drm-ttm is not set
+# CONFIG_PACKAGE_kmod-fb is not set
+# CONFIG_PACKAGE_kmod-fb-cfb-copyarea is not set
+# CONFIG_PACKAGE_kmod-fb-cfb-fillrect is not set
+# CONFIG_PACKAGE_kmod-fb-cfb-imgblt is not set
+# CONFIG_PACKAGE_kmod-fb-sys-fops is not set
+# CONFIG_PACKAGE_kmod-fb-sys-ram is not set
+# CONFIG_PACKAGE_kmod-fb-tft is not set
+# CONFIG_PACKAGE_kmod-fb-tft-ili9486 is not set
 # CONFIG_PACKAGE_kmod-video-core is not set
 
 #
@@ -2251,7 +2344,6 @@ CONFIG_PACKAGE_kmod-usb2=y
 #
 # Voice over IP
 #
-# CONFIG_PACKAGE_kmod-dahdi is not set
 
 #
 # W1 support
@@ -2311,56 +2403,11 @@ CONFIG_PACKAGE_MAC80211_DEBUGFS=y
 CONFIG_PACKAGE_MAC80211_MESH=y
 # CONFIG_PACKAGE_kmod-mac80211-hwsim is not set
 # CONFIG_PACKAGE_kmod-mt76 is not set
+CONFIG_PACKAGE_kmod-mt76-core=y
 # CONFIG_PACKAGE_kmod-mt7601u is not set
-# CONFIG_PACKAGE_kmod-mt7603 is not set
+CONFIG_PACKAGE_kmod-mt7603=y
 # CONFIG_PACKAGE_kmod-mt7615e is not set
-CONFIG_PACKAGE_kmod-mt7628=y
-CONFIG_MT7628_RT_FIRST_CARD=7628
-CONFIG_MT7628_MT_WIFI=y
-CONFIG_MT7628_MT_WIFI_PATH="rlt_wifi"
-
-#
-# WiFi Generic Feature Options
-#
-CONFIG_MT7628_FIRST_IF_EEPROM_FLASH=y
-CONFIG_MT7628_RT_FIRST_CARD_EEPROM="flash"
-CONFIG_MT7628_SECOND_IF_EEPROM_FLASH=y
-CONFIG_MT7628_RT_SECOND_CARD_EEPROM="flash"
-# CONFIG_MT7628_MULTI_INF_SUPPORT is not set
-CONFIG_MT7628_WIFI_BASIC_FUNC=y
-CONFIG_MT7628_WSC_INCLUDED=y
-CONFIG_MT7628_WSC_V2_SUPPORT=y
-CONFIG_MT7628_DOT11N_DRAFT3=y
-CONFIG_MT7628_DOT11W_PMF_SUPPORT=y
-# CONFIG_MT7628_LLTD_SUPPORT is not set
-CONFIG_MT7628_QOS_DLS_SUPPORT=y
-# CONFIG_MT7628_WAPI_SUPPORT is not set
-# CONFIG_MT7628_IGMP_SNOOP_SUPPORT is not set
-# CONFIG_MT7628_BLOCK_NET_IF is not set
-CONFIG_MT7628_RATE_ADAPTION=y
-CONFIG_MT7628_NEW_RATE_ADAPT_SUPPORT=y
-# CONFIG_MT7628_AGS_SUPPORT is not set
-# CONFIG_MT7628_IDS_SUPPORT is not set
-# CONFIG_MT7628_WIFI_WORK_QUEUE is not set
-# CONFIG_MT7628_WIFI_SKB_RECYCLE is not set
-# CONFIG_MT7628_LED_CONTROL_SUPPORT is not set
-# CONFIG_MT7628_ATE_SUPPORT is not set
-# CONFIG_MT7628_MEMORY_OPTIMIZATION is not set
-CONFIG_MT7628_UAPSD=y
-CONFIG_MT7628_MT_MAC=y
-
-#
-# WiFi Operation Modes
-#
-CONFIG_MT7628_WIFI_MODE_AP=y
-CONFIG_MT7628_MT_AP_SUPPORT=y
-# CONFIG_MT7628_WDS_SUPPORT is not set
-CONFIG_MT7628_MBSS_SUPPORT=y
-CONFIG_MT7628_APCLI_SUPPORT=y
-# CONFIG_MT7628_MAC_REPEATER_SUPPORT is not set
-CONFIG_MT7628_SNIFFER_SUPPORT=y
-# CONFIG_MT7628_CON_WPS_SUPPORT is not set
-# CONFIG_MT7628_AIREPLAY_SUPPORT is not set
+# CONFIG_PACKAGE_kmod-mt7628 is not set
 # CONFIG_PACKAGE_kmod-mt76x0e is not set
 # CONFIG_PACKAGE_kmod-mt76x0u is not set
 # CONFIG_PACKAGE_kmod-mt76x2 is not set
@@ -2404,587 +2451,11 @@ CONFIG_MT7628_SNIFFER_SUPPORT=y
 #
 
 #
-# Erlang
-#
-# CONFIG_PACKAGE_erlang is not set
-# CONFIG_PACKAGE_erlang-asn1 is not set
-# CONFIG_PACKAGE_erlang-compiler is not set
-# CONFIG_PACKAGE_erlang-crypto is not set
-# CONFIG_PACKAGE_erlang-erl-interface is not set
-# CONFIG_PACKAGE_erlang-hipe is not set
-# CONFIG_PACKAGE_erlang-inets is not set
-# CONFIG_PACKAGE_erlang-mnesia is not set
-# CONFIG_PACKAGE_erlang-os_mon is not set
-# CONFIG_PACKAGE_erlang-public-key is not set
-# CONFIG_PACKAGE_erlang-reltool is not set
-# CONFIG_PACKAGE_erlang-runtime-tools is not set
-# CONFIG_PACKAGE_erlang-snmp is not set
-# CONFIG_PACKAGE_erlang-ssh is not set
-# CONFIG_PACKAGE_erlang-ssl is not set
-# CONFIG_PACKAGE_erlang-syntax-tools is not set
-# CONFIG_PACKAGE_erlang-tools is not set
-# CONFIG_PACKAGE_erlang-xmerl is not set
-
-#
-# Go
-#
-# CONFIG_PACKAGE_golang is not set
-# CONFIG_PACKAGE_golang-doc is not set
-# CONFIG_PACKAGE_golang-github-jedisct1-dnscrypt-proxy2-dev is not set
-# CONFIG_PACKAGE_golang-github-nextdns-nextdns-dev is not set
-# CONFIG_PACKAGE_golang-gitlab-yawning-obfs4-dev is not set
-# CONFIG_PACKAGE_golang-src is not set
-# CONFIG_PACKAGE_golang-torproject-tor-fw-helper-dev is not set
-
-#
-# Java
-#
-# CONFIG_PACKAGE_jamvm is not set
-
-#
 # Lua
 #
-# CONFIG_PACKAGE_dkjson is not set
-# CONFIG_PACKAGE_json4lua is not set
-# CONFIG_PACKAGE_ldbus is not set
 # CONFIG_PACKAGE_libiwinfo-lua is not set
-# CONFIG_PACKAGE_lpeg is not set
-# CONFIG_PACKAGE_lsqlite3 is not set
 # CONFIG_PACKAGE_lua is not set
-# CONFIG_PACKAGE_lua-bencode is not set
-# CONFIG_PACKAGE_lua-cjson is not set
-# CONFIG_PACKAGE_lua-copas is not set
-# CONFIG_PACKAGE_lua-coxpcall is not set
-# CONFIG_PACKAGE_lua-ev is not set
-# CONFIG_PACKAGE_lua-libmodbus is not set
-# CONFIG_PACKAGE_lua-lzlib is not set
-# CONFIG_PACKAGE_lua-md5 is not set
-# CONFIG_PACKAGE_lua-mobdebug is not set
-# CONFIG_PACKAGE_lua-mosquitto is not set
-# CONFIG_PACKAGE_lua-openssl is not set
-# CONFIG_PACKAGE_lua-penlight is not set
-# CONFIG_PACKAGE_lua-rings is not set
-# CONFIG_PACKAGE_lua-rs232 is not set
-# CONFIG_PACKAGE_lua-sha2 is not set
-# CONFIG_PACKAGE_lua-wsapi-base is not set
-# CONFIG_PACKAGE_lua-wsapi-xavante is not set
-# CONFIG_PACKAGE_lua-xavante is not set
-# CONFIG_PACKAGE_luabitop is not set
 # CONFIG_PACKAGE_luac is not set
-# CONFIG_PACKAGE_luaexpat is not set
-# CONFIG_PACKAGE_luafilesystem is not set
-# CONFIG_PACKAGE_luajit is not set
-# CONFIG_PACKAGE_lualanes is not set
-# CONFIG_PACKAGE_luaposix is not set
-# CONFIG_PACKAGE_luarocks is not set
-# CONFIG_PACKAGE_luasec is not set
-# CONFIG_PACKAGE_luasoap is not set
-# CONFIG_PACKAGE_luasocket is not set
-# CONFIG_PACKAGE_luasql-mysql is not set
-# CONFIG_PACKAGE_luasql-pgsql is not set
-# CONFIG_PACKAGE_luasql-sqlite3 is not set
-# CONFIG_PACKAGE_luasrcdiet is not set
-# CONFIG_PACKAGE_luv is not set
-# CONFIG_PACKAGE_lzmq is not set
-# CONFIG_PACKAGE_uuid is not set
-
-#
-# Node.js
-#
-
-#
-# PHP
-#
-# CONFIG_PACKAGE_php7 is not set
-
-#
-# Perl
-#
-# CONFIG_PACKAGE_perl is not set
-
-#
-# Python
-#
-# CONFIG_PACKAGE_gunicorn is not set
-# CONFIG_PACKAGE_micropython is not set
-# CONFIG_PACKAGE_micropython-lib is not set
-# CONFIG_PACKAGE_python is not set
-# CONFIG_PACKAGE_python-asn1crypto is not set
-# CONFIG_PACKAGE_python-astral is not set
-# CONFIG_PACKAGE_python-astral-src is not set
-# CONFIG_PACKAGE_python-attrs is not set
-# CONFIG_PACKAGE_python-attrs-src is not set
-# CONFIG_PACKAGE_python-automat is not set
-# CONFIG_PACKAGE_python-automat-src is not set
-# CONFIG_PACKAGE_python-awscli is not set
-# CONFIG_PACKAGE_python-awscli-src is not set
-# CONFIG_PACKAGE_python-base is not set
-# CONFIG_PACKAGE_python-base-src is not set
-# CONFIG_PACKAGE_python-bcrypt is not set
-# CONFIG_PACKAGE_python-bcrypt-src is not set
-# CONFIG_PACKAGE_python-botocore is not set
-# CONFIG_PACKAGE_python-botocore-src is not set
-# CONFIG_PACKAGE_python-certifi is not set
-# CONFIG_PACKAGE_python-certifi-src is not set
-# CONFIG_PACKAGE_python-cffi is not set
-# CONFIG_PACKAGE_python-cffi-src is not set
-# CONFIG_PACKAGE_python-chardet is not set
-# CONFIG_PACKAGE_python-chardet-src is not set
-# CONFIG_PACKAGE_python-codecs is not set
-# CONFIG_PACKAGE_python-codecs-src is not set
-# CONFIG_PACKAGE_python-colorama is not set
-# CONFIG_PACKAGE_python-colorama-src is not set
-# CONFIG_PACKAGE_python-compiler is not set
-# CONFIG_PACKAGE_python-compiler-src is not set
-# CONFIG_PACKAGE_python-constantly is not set
-# CONFIG_PACKAGE_python-constantly-src is not set
-# CONFIG_PACKAGE_python-crcmod is not set
-# CONFIG_PACKAGE_python-crypto is not set
-# CONFIG_PACKAGE_python-crypto-src is not set
-# CONFIG_PACKAGE_python-cryptodome is not set
-# CONFIG_PACKAGE_python-cryptodome-src is not set
-# CONFIG_PACKAGE_python-cryptodomex is not set
-# CONFIG_PACKAGE_python-cryptodomex-src is not set
-# CONFIG_PACKAGE_python-cryptography is not set
-# CONFIG_PACKAGE_python-cryptography-src is not set
-# CONFIG_PACKAGE_python-ctypes is not set
-# CONFIG_PACKAGE_python-ctypes-src is not set
-# CONFIG_PACKAGE_python-curl is not set
-# CONFIG_PACKAGE_python-curl-src is not set
-# CONFIG_PACKAGE_python-dateutil is not set
-# CONFIG_PACKAGE_python-dateutil-src is not set
-# CONFIG_PACKAGE_python-db is not set
-# CONFIG_PACKAGE_python-db-src is not set
-# CONFIG_PACKAGE_python-decimal is not set
-# CONFIG_PACKAGE_python-decimal-src is not set
-# CONFIG_PACKAGE_python-defusedxml is not set
-# CONFIG_PACKAGE_python-defusedxml-src is not set
-# CONFIG_PACKAGE_python-dev is not set
-# CONFIG_PACKAGE_python-dev-src is not set
-# CONFIG_PACKAGE_python-distutils is not set
-# CONFIG_PACKAGE_python-distutils-src is not set
-# CONFIG_PACKAGE_python-django is not set
-# CONFIG_PACKAGE_python-dns is not set
-# CONFIG_PACKAGE_python-dns-src is not set
-# CONFIG_PACKAGE_python-docutils is not set
-# CONFIG_PACKAGE_python-docutils-src is not set
-# CONFIG_PACKAGE_python-dpkt is not set
-# CONFIG_PACKAGE_python-egenix-mx-base is not set
-# CONFIG_PACKAGE_python-email is not set
-# CONFIG_PACKAGE_python-email-src is not set
-# CONFIG_PACKAGE_python-enum34 is not set
-# CONFIG_PACKAGE_python-enum34-src is not set
-# CONFIG_PACKAGE_python-et_xmlfile is not set
-# CONFIG_PACKAGE_python-et_xmlfile-src is not set
-# CONFIG_PACKAGE_python-evdev is not set
-# CONFIG_PACKAGE_python-flup is not set
-# CONFIG_PACKAGE_python-flup-src is not set
-# CONFIG_PACKAGE_python-futures is not set
-# CONFIG_PACKAGE_python-futures-src is not set
-# CONFIG_PACKAGE_python-gdbm is not set
-# CONFIG_PACKAGE_python-gdbm-src is not set
-# CONFIG_PACKAGE_python-gmpy2 is not set
-# CONFIG_PACKAGE_python-gmpy2-src is not set
-# CONFIG_PACKAGE_python-gnupg is not set
-# CONFIG_PACKAGE_python-hyperlink is not set
-# CONFIG_PACKAGE_python-hyperlink-src is not set
-# CONFIG_PACKAGE_python-idna is not set
-# CONFIG_PACKAGE_python-idna-src is not set
-# CONFIG_PACKAGE_python-incremental is not set
-# CONFIG_PACKAGE_python-incremental-src is not set
-# CONFIG_PACKAGE_python-ipaddress is not set
-# CONFIG_PACKAGE_python-ipaddress-src is not set
-# CONFIG_PACKAGE_python-jdcal is not set
-# CONFIG_PACKAGE_python-jdcal-src is not set
-# CONFIG_PACKAGE_python-jmespath is not set
-# CONFIG_PACKAGE_python-jmespath-src is not set
-# CONFIG_PACKAGE_python-ldap is not set
-# CONFIG_PACKAGE_python-lib2to3 is not set
-# CONFIG_PACKAGE_python-lib2to3-src is not set
-# CONFIG_PACKAGE_python-light is not set
-
-#
-# Configuration
-#
-# CONFIG_PYTHON_BLUETOOTH_SUPPORT is not set
-# CONFIG_PACKAGE_python-light-src is not set
-# CONFIG_PACKAGE_python-logging is not set
-# CONFIG_PACKAGE_python-logging-src is not set
-# CONFIG_PACKAGE_python-lxml is not set
-# CONFIG_PACKAGE_python-multiprocessing is not set
-# CONFIG_PACKAGE_python-multiprocessing-src is not set
-# CONFIG_PACKAGE_python-mysql is not set
-# CONFIG_PACKAGE_python-ncurses is not set
-# CONFIG_PACKAGE_python-ncurses-src is not set
-# CONFIG_PACKAGE_python-oauthlib is not set
-# CONFIG_PACKAGE_python-oauthlib-src is not set
-# CONFIG_PACKAGE_python-openpyxl is not set
-# CONFIG_PACKAGE_python-openpyxl-src is not set
-# CONFIG_PACKAGE_python-openssl is not set
-# CONFIG_PACKAGE_python-openssl-src is not set
-# CONFIG_PACKAGE_python-parsley is not set
-# CONFIG_PACKAGE_python-parsley-src is not set
-# CONFIG_PACKAGE_python-passlib is not set
-# CONFIG_PACKAGE_python-passlib-src is not set
-# CONFIG_PACKAGE_python-pcapy is not set
-# CONFIG_PACKAGE_python-pillow is not set
-# CONFIG_PACKAGE_python-pillow-src is not set
-# CONFIG_PACKAGE_python-pip is not set
-# CONFIG_PACKAGE_python-pip-conf is not set
-# CONFIG_PACKAGE_python-pip-src is not set
-# CONFIG_PACKAGE_python-pkg-resources is not set
-# CONFIG_PACKAGE_python-pkg-resources-src is not set
-# CONFIG_PACKAGE_python-ply is not set
-# CONFIG_PACKAGE_python-ply-src is not set
-# CONFIG_PACKAGE_python-psycopg2 is not set
-# CONFIG_PACKAGE_python-pyasn1 is not set
-# CONFIG_PACKAGE_python-pyasn1-modules is not set
-# CONFIG_PACKAGE_python-pyasn1-modules-src is not set
-# CONFIG_PACKAGE_python-pyasn1-src is not set
-# CONFIG_PACKAGE_python-pycparser is not set
-# CONFIG_PACKAGE_python-pycparser-src is not set
-# CONFIG_PACKAGE_python-pydoc is not set
-# CONFIG_PACKAGE_python-pydoc-src is not set
-# CONFIG_PACKAGE_python-pyjwt is not set
-# CONFIG_PACKAGE_python-pyjwt-src is not set
-# CONFIG_PACKAGE_python-pyodbc is not set
-# CONFIG_PACKAGE_python-pyopenssl is not set
-# CONFIG_PACKAGE_python-pyopenssl-src is not set
-# CONFIG_PACKAGE_python-pyptlib is not set
-# CONFIG_PACKAGE_python-pyptlib-src is not set
-# CONFIG_PACKAGE_python-pyserial is not set
-# CONFIG_PACKAGE_python-pyserial-src is not set
-# CONFIG_PACKAGE_python-pytz is not set
-# CONFIG_PACKAGE_python-pytz-src is not set
-# CONFIG_PACKAGE_python-qrcode is not set
-# CONFIG_PACKAGE_python-qrcode-src is not set
-# CONFIG_PACKAGE_python-rcssmin is not set
-# CONFIG_PACKAGE_python-rcssmin-src is not set
-# CONFIG_PACKAGE_python-requests is not set
-# CONFIG_PACKAGE_python-requests-oauthlib is not set
-# CONFIG_PACKAGE_python-requests-oauthlib-src is not set
-# CONFIG_PACKAGE_python-requests-src is not set
-# CONFIG_PACKAGE_python-rsa is not set
-# CONFIG_PACKAGE_python-rsa-src is not set
-# CONFIG_PACKAGE_python-ruamel-yaml is not set
-# CONFIG_PACKAGE_python-ruamel-yaml-src is not set
-# CONFIG_PACKAGE_python-s3transfer is not set
-# CONFIG_PACKAGE_python-s3transfer-src is not set
-# CONFIG_PACKAGE_python-service-identity is not set
-# CONFIG_PACKAGE_python-service-identity-src is not set
-# CONFIG_PACKAGE_python-setuptools is not set
-# CONFIG_PACKAGE_python-setuptools-src is not set
-# CONFIG_PACKAGE_python-simplejson is not set
-# CONFIG_PACKAGE_python-simplejson-src is not set
-# CONFIG_PACKAGE_python-six is not set
-# CONFIG_PACKAGE_python-six-src is not set
-# CONFIG_PACKAGE_python-smbus is not set
-# CONFIG_PACKAGE_python-sqlite3 is not set
-# CONFIG_PACKAGE_python-sqlite3-src is not set
-# CONFIG_PACKAGE_python-text-unidecode is not set
-# CONFIG_PACKAGE_python-text-unidecode-src is not set
-# CONFIG_PACKAGE_python-twisted is not set
-# CONFIG_PACKAGE_python-twisted-src is not set
-# CONFIG_PACKAGE_python-txsocksx is not set
-# CONFIG_PACKAGE_python-txsocksx-src is not set
-# CONFIG_PACKAGE_python-unittest is not set
-# CONFIG_PACKAGE_python-unittest-src is not set
-# CONFIG_PACKAGE_python-urllib3 is not set
-# CONFIG_PACKAGE_python-urllib3-src is not set
-# CONFIG_PACKAGE_python-vobject is not set
-# CONFIG_PACKAGE_python-vobject-src is not set
-# CONFIG_PACKAGE_python-voluptuous is not set
-# CONFIG_PACKAGE_python-voluptuous-src is not set
-# CONFIG_PACKAGE_python-xml is not set
-# CONFIG_PACKAGE_python-xml-src is not set
-# CONFIG_PACKAGE_python-yaml is not set
-# CONFIG_PACKAGE_python-yaml-src is not set
-# CONFIG_PACKAGE_python-zope-interface is not set
-# CONFIG_PACKAGE_python-zope-interface-src is not set
-# CONFIG_PACKAGE_python3 is not set
-# CONFIG_PACKAGE_python3-aiohttp is not set
-# CONFIG_PACKAGE_python3-aiohttp-cors is not set
-# CONFIG_PACKAGE_python3-aiohttp-cors-src is not set
-# CONFIG_PACKAGE_python3-aiohttp-src is not set
-# CONFIG_PACKAGE_python3-appdirs is not set
-# CONFIG_PACKAGE_python3-appdirs-src is not set
-# CONFIG_PACKAGE_python3-asn1crypto is not set
-# CONFIG_PACKAGE_python3-astral is not set
-# CONFIG_PACKAGE_python3-astral-src is not set
-# CONFIG_PACKAGE_python3-async-timeout is not set
-# CONFIG_PACKAGE_python3-async-timeout-src is not set
-# CONFIG_PACKAGE_python3-asyncio is not set
-# CONFIG_PACKAGE_python3-asyncio-src is not set
-# CONFIG_PACKAGE_python3-attrs is not set
-# CONFIG_PACKAGE_python3-attrs-src is not set
-# CONFIG_PACKAGE_python3-automat is not set
-# CONFIG_PACKAGE_python3-automat-src is not set
-# CONFIG_PACKAGE_python3-awscli is not set
-# CONFIG_PACKAGE_python3-awscli-src is not set
-# CONFIG_PACKAGE_python3-base is not set
-# CONFIG_PACKAGE_python3-base-src is not set
-# CONFIG_PACKAGE_python3-bcrypt is not set
-# CONFIG_PACKAGE_python3-bcrypt-src is not set
-# CONFIG_PACKAGE_python3-boto3 is not set
-# CONFIG_PACKAGE_python3-boto3-src is not set
-# CONFIG_PACKAGE_python3-botocore is not set
-# CONFIG_PACKAGE_python3-botocore-src is not set
-# CONFIG_PACKAGE_python3-bottle is not set
-# CONFIG_PACKAGE_python3-bottle-src is not set
-# CONFIG_PACKAGE_python3-cachelib is not set
-# CONFIG_PACKAGE_python3-cachelib-src is not set
-# CONFIG_PACKAGE_python3-cachetools is not set
-# CONFIG_PACKAGE_python3-cachetools-src is not set
-# CONFIG_PACKAGE_python3-certifi is not set
-# CONFIG_PACKAGE_python3-certifi-src is not set
-# CONFIG_PACKAGE_python3-cffi is not set
-# CONFIG_PACKAGE_python3-cffi-src is not set
-# CONFIG_PACKAGE_python3-cgi is not set
-# CONFIG_PACKAGE_python3-cgi-src is not set
-# CONFIG_PACKAGE_python3-cgitb is not set
-# CONFIG_PACKAGE_python3-cgitb-src is not set
-# CONFIG_PACKAGE_python3-chardet is not set
-# CONFIG_PACKAGE_python3-chardet-src is not set
-# CONFIG_PACKAGE_python3-click is not set
-# CONFIG_PACKAGE_python3-click-log is not set
-# CONFIG_PACKAGE_python3-click-log-src is not set
-# CONFIG_PACKAGE_python3-click-src is not set
-# CONFIG_PACKAGE_python3-codecs is not set
-# CONFIG_PACKAGE_python3-codecs-src is not set
-# CONFIG_PACKAGE_python3-colorama is not set
-# CONFIG_PACKAGE_python3-colorama-src is not set
-# CONFIG_PACKAGE_python3-constantly is not set
-# CONFIG_PACKAGE_python3-constantly-src is not set
-# CONFIG_PACKAGE_python3-contextlib2 is not set
-# CONFIG_PACKAGE_python3-contextlib2-src is not set
-# CONFIG_PACKAGE_python3-crypto is not set
-# CONFIG_PACKAGE_python3-crypto-src is not set
-# CONFIG_PACKAGE_python3-cryptodome is not set
-# CONFIG_PACKAGE_python3-cryptodome-src is not set
-# CONFIG_PACKAGE_python3-cryptodomex is not set
-# CONFIG_PACKAGE_python3-cryptodomex-src is not set
-# CONFIG_PACKAGE_python3-cryptography is not set
-# CONFIG_PACKAGE_python3-cryptography-src is not set
-# CONFIG_PACKAGE_python3-ctypes is not set
-# CONFIG_PACKAGE_python3-ctypes-src is not set
-# CONFIG_PACKAGE_python3-curl is not set
-# CONFIG_PACKAGE_python3-curl-src is not set
-# CONFIG_PACKAGE_python3-dateutil is not set
-# CONFIG_PACKAGE_python3-dateutil-src is not set
-# CONFIG_PACKAGE_python3-dbm is not set
-# CONFIG_PACKAGE_python3-dbm-src is not set
-# CONFIG_PACKAGE_python3-decimal is not set
-# CONFIG_PACKAGE_python3-decimal-src is not set
-# CONFIG_PACKAGE_python3-decorator is not set
-# CONFIG_PACKAGE_python3-decorator-src is not set
-# CONFIG_PACKAGE_python3-defusedxml is not set
-# CONFIG_PACKAGE_python3-defusedxml-src is not set
-# CONFIG_PACKAGE_python3-dev is not set
-# CONFIG_PACKAGE_python3-dev-src is not set
-# CONFIG_PACKAGE_python3-distutils is not set
-# CONFIG_PACKAGE_python3-distutils-src is not set
-# CONFIG_PACKAGE_python3-django is not set
-# CONFIG_PACKAGE_python3-dns is not set
-# CONFIG_PACKAGE_python3-dns-src is not set
-# CONFIG_PACKAGE_python3-docutils is not set
-# CONFIG_PACKAGE_python3-docutils-src is not set
-# CONFIG_PACKAGE_python3-email is not set
-# CONFIG_PACKAGE_python3-email-src is not set
-# CONFIG_PACKAGE_python3-et_xmlfile is not set
-# CONFIG_PACKAGE_python3-et_xmlfile-src is not set
-# CONFIG_PACKAGE_python3-evdev is not set
-# CONFIG_PACKAGE_python3-flask is not set
-# CONFIG_PACKAGE_python3-flask-login is not set
-# CONFIG_PACKAGE_python3-flask-login-src is not set
-# CONFIG_PACKAGE_python3-flask-src is not set
-# CONFIG_PACKAGE_python3-flup is not set
-# CONFIG_PACKAGE_python3-flup-src is not set
-# CONFIG_PACKAGE_python3-gdbm is not set
-# CONFIG_PACKAGE_python3-gdbm-src is not set
-# CONFIG_PACKAGE_python3-gmpy2 is not set
-# CONFIG_PACKAGE_python3-gmpy2-src is not set
-# CONFIG_PACKAGE_python3-gnupg is not set
-# CONFIG_PACKAGE_python3-hyperlink is not set
-# CONFIG_PACKAGE_python3-hyperlink-src is not set
-# CONFIG_PACKAGE_python3-idna is not set
-# CONFIG_PACKAGE_python3-idna-src is not set
-# CONFIG_PACKAGE_python3-ifaddr is not set
-# CONFIG_PACKAGE_python3-ifaddr-src is not set
-# CONFIG_PACKAGE_python3-importlib-metadata is not set
-# CONFIG_PACKAGE_python3-importlib-metadata-src is not set
-# CONFIG_PACKAGE_python3-incremental is not set
-# CONFIG_PACKAGE_python3-incremental-src is not set
-# CONFIG_PACKAGE_python3-influxdb is not set
-# CONFIG_PACKAGE_python3-influxdb-src is not set
-# CONFIG_PACKAGE_python3-intelhex is not set
-# CONFIG_PACKAGE_python3-intelhex-src is not set
-# CONFIG_PACKAGE_python3-itsdangerous is not set
-# CONFIG_PACKAGE_python3-jdcal is not set
-# CONFIG_PACKAGE_python3-jdcal-src is not set
-# CONFIG_PACKAGE_python3-jinja2 is not set
-# CONFIG_PACKAGE_python3-jinja2-src is not set
-# CONFIG_PACKAGE_python3-jmespath is not set
-# CONFIG_PACKAGE_python3-jmespath-src is not set
-# CONFIG_PACKAGE_python3-jsonpath-ng is not set
-# CONFIG_PACKAGE_python3-jsonpath-ng-src is not set
-# CONFIG_PACKAGE_python3-lib2to3 is not set
-# CONFIG_PACKAGE_python3-lib2to3-src is not set
-# CONFIG_PACKAGE_python3-light is not set
-
-#
-# Configuration
-#
-# CONFIG_PYTHON3_BLUETOOTH_SUPPORT is not set
-# CONFIG_PACKAGE_python3-light-src is not set
-# CONFIG_PACKAGE_python3-logging is not set
-# CONFIG_PACKAGE_python3-logging-src is not set
-# CONFIG_PACKAGE_python3-lxml is not set
-# CONFIG_PACKAGE_python3-lzma is not set
-# CONFIG_PACKAGE_python3-lzma-src is not set
-# CONFIG_PACKAGE_python3-markdown is not set
-# CONFIG_PACKAGE_python3-markdown-src is not set
-# CONFIG_PACKAGE_python3-markupsafe is not set
-# CONFIG_PACKAGE_python3-maxminddb is not set
-# CONFIG_PACKAGE_python3-maxminddb-src is not set
-# CONFIG_PACKAGE_python3-more-itertools is not set
-# CONFIG_PACKAGE_python3-more-itertools-src is not set
-# CONFIG_PACKAGE_python3-multidict is not set
-# CONFIG_PACKAGE_python3-multidict-src is not set
-# CONFIG_PACKAGE_python3-multiprocessing is not set
-# CONFIG_PACKAGE_python3-multiprocessing-src is not set
-# CONFIG_PACKAGE_python3-mysql is not set
-# CONFIG_PACKAGE_python3-ncurses is not set
-# CONFIG_PACKAGE_python3-ncurses-src is not set
-# CONFIG_PACKAGE_python3-netdisco is not set
-# CONFIG_PACKAGE_python3-netdisco-src is not set
-# CONFIG_PACKAGE_python3-netifaces is not set
-# CONFIG_PACKAGE_python3-netifaces-src is not set
-# CONFIG_PACKAGE_python3-newt is not set
-# CONFIG_PACKAGE_python3-newt-src is not set
-# CONFIG_PACKAGE_python3-oauthlib is not set
-# CONFIG_PACKAGE_python3-oauthlib-src is not set
-# CONFIG_PACKAGE_python3-openpyxl is not set
-# CONFIG_PACKAGE_python3-openpyxl-src is not set
-# CONFIG_PACKAGE_python3-openssl is not set
-# CONFIG_PACKAGE_python3-openssl-src is not set
-# CONFIG_PACKAGE_python3-paho-mqtt is not set
-# CONFIG_PACKAGE_python3-paho-mqtt-src is not set
-# CONFIG_PACKAGE_python3-parsley is not set
-# CONFIG_PACKAGE_python3-parsley-src is not set
-# CONFIG_PACKAGE_python3-passlib is not set
-# CONFIG_PACKAGE_python3-passlib-src is not set
-# CONFIG_PACKAGE_python3-pillow is not set
-# CONFIG_PACKAGE_python3-pillow-src is not set
-# CONFIG_PACKAGE_python3-pip is not set
-# CONFIG_PACKAGE_python3-pip-src is not set
-# CONFIG_PACKAGE_python3-pkg-resources is not set
-# CONFIG_PACKAGE_python3-pkg-resources-src is not set
-# CONFIG_PACKAGE_python3-ply is not set
-# CONFIG_PACKAGE_python3-ply-src is not set
-# CONFIG_PACKAGE_python3-pyasn1 is not set
-# CONFIG_PACKAGE_python3-pyasn1-modules is not set
-# CONFIG_PACKAGE_python3-pyasn1-modules-src is not set
-# CONFIG_PACKAGE_python3-pyasn1-src is not set
-# CONFIG_PACKAGE_python3-pycparser is not set
-# CONFIG_PACKAGE_python3-pycparser-src is not set
-# CONFIG_PACKAGE_python3-pydoc is not set
-# CONFIG_PACKAGE_python3-pydoc-src is not set
-# CONFIG_PACKAGE_python3-pyjwt is not set
-# CONFIG_PACKAGE_python3-pyjwt-src is not set
-# CONFIG_PACKAGE_python3-pyodbc is not set
-# CONFIG_PACKAGE_python3-pyopenssl is not set
-# CONFIG_PACKAGE_python3-pyopenssl-src is not set
-# CONFIG_PACKAGE_python3-pyotp is not set
-# CONFIG_PACKAGE_python3-pyotp-src is not set
-# CONFIG_PACKAGE_python3-pyroute2 is not set
-# CONFIG_PACKAGE_python3-pyroute2-src is not set
-# CONFIG_PACKAGE_python3-pyrsistent is not set
-# CONFIG_PACKAGE_python3-pyrsistent-src is not set
-# CONFIG_PACKAGE_python3-pyserial is not set
-# CONFIG_PACKAGE_python3-pyserial-src is not set
-# CONFIG_PACKAGE_python3-pytz is not set
-# CONFIG_PACKAGE_python3-pytz-src is not set
-# CONFIG_PACKAGE_python3-qrcode is not set
-# CONFIG_PACKAGE_python3-qrcode-src is not set
-# CONFIG_PACKAGE_python3-rcssmin is not set
-# CONFIG_PACKAGE_python3-rcssmin-src is not set
-# CONFIG_PACKAGE_python3-requests is not set
-# CONFIG_PACKAGE_python3-requests-oauthlib is not set
-# CONFIG_PACKAGE_python3-requests-oauthlib-src is not set
-# CONFIG_PACKAGE_python3-requests-src is not set
-# CONFIG_PACKAGE_python3-rsa is not set
-# CONFIG_PACKAGE_python3-rsa-src is not set
-# CONFIG_PACKAGE_python3-ruamel-yaml is not set
-# CONFIG_PACKAGE_python3-ruamel-yaml-src is not set
-# CONFIG_PACKAGE_python3-s3transfer is not set
-# CONFIG_PACKAGE_python3-s3transfer-src is not set
-# CONFIG_PACKAGE_python3-schema is not set
-# CONFIG_PACKAGE_python3-schema-src is not set
-# CONFIG_PACKAGE_python3-sentry-sdk is not set
-# CONFIG_PACKAGE_python3-sentry-sdk-src is not set
-# CONFIG_PACKAGE_python3-service-identity is not set
-# CONFIG_PACKAGE_python3-service-identity-src is not set
-# CONFIG_PACKAGE_python3-setuptools is not set
-# CONFIG_PACKAGE_python3-setuptools-src is not set
-# CONFIG_PACKAGE_python3-simplejson is not set
-# CONFIG_PACKAGE_python3-simplejson-src is not set
-# CONFIG_PACKAGE_python3-six is not set
-# CONFIG_PACKAGE_python3-six-src is not set
-# CONFIG_PACKAGE_python3-slugify is not set
-# CONFIG_PACKAGE_python3-slugify-src is not set
-# CONFIG_PACKAGE_python3-smbus is not set
-# CONFIG_PACKAGE_python3-sqlalchemy is not set
-# CONFIG_PACKAGE_python3-sqlalchemy-src is not set
-# CONFIG_PACKAGE_python3-sqlite3 is not set
-# CONFIG_PACKAGE_python3-sqlite3-src is not set
-# CONFIG_PACKAGE_python3-text-unidecode is not set
-# CONFIG_PACKAGE_python3-text-unidecode-src is not set
-# CONFIG_PACKAGE_python3-twisted is not set
-# CONFIG_PACKAGE_python3-twisted-src is not set
-# CONFIG_PACKAGE_python3-unidecode is not set
-# CONFIG_PACKAGE_python3-unidecode-src is not set
-# CONFIG_PACKAGE_python3-unittest is not set
-# CONFIG_PACKAGE_python3-unittest-src is not set
-# CONFIG_PACKAGE_python3-urllib is not set
-# CONFIG_PACKAGE_python3-urllib-src is not set
-# CONFIG_PACKAGE_python3-urllib3 is not set
-# CONFIG_PACKAGE_python3-urllib3-src is not set
-# CONFIG_PACKAGE_python3-vobject is not set
-# CONFIG_PACKAGE_python3-vobject-src is not set
-# CONFIG_PACKAGE_python3-voluptuous is not set
-# CONFIG_PACKAGE_python3-voluptuous-serialize is not set
-# CONFIG_PACKAGE_python3-voluptuous-serialize-src is not set
-# CONFIG_PACKAGE_python3-voluptuous-src is not set
-# CONFIG_PACKAGE_python3-werkzeug is not set
-# CONFIG_PACKAGE_python3-werkzeug-src is not set
-# CONFIG_PACKAGE_python3-xml is not set
-# CONFIG_PACKAGE_python3-xml-src is not set
-# CONFIG_PACKAGE_python3-xmltodict is not set
-# CONFIG_PACKAGE_python3-xmltodict-src is not set
-# CONFIG_PACKAGE_python3-yaml is not set
-# CONFIG_PACKAGE_python3-yaml-src is not set
-# CONFIG_PACKAGE_python3-yarl is not set
-# CONFIG_PACKAGE_python3-yarl-src is not set
-# CONFIG_PACKAGE_python3-zeroconf is not set
-# CONFIG_PACKAGE_python3-zeroconf-src is not set
-# CONFIG_PACKAGE_python3-zipp is not set
-# CONFIG_PACKAGE_python3-zipp-src is not set
-# CONFIG_PACKAGE_python3-zope-interface is not set
-# CONFIG_PACKAGE_python3-zope-interface-src is not set
-
-#
-# Ruby
-#
-# CONFIG_PACKAGE_ruby is not set
-# CONFIG_PACKAGE_ruby-dev is not set
-
-#
-# Tcl
-#
-# CONFIG_PACKAGE_tcl is not set
-# CONFIG_PACKAGE_chicken-scheme-interpreter is not set
-# CONFIG_PACKAGE_slsh is not set
-# CONFIG_PACKAGE_vala is not set
 
 #
 # Libraries
@@ -2994,29 +2465,16 @@ CONFIG_MT7628_SNIFFER_SUPPORT=y
 # Compression
 #
 # CONFIG_PACKAGE_libbz2 is not set
-# CONFIG_PACKAGE_liblz4 is not set
-# CONFIG_PACKAGE_liblzma is not set
-# CONFIG_PACKAGE_libunrar is not set
-# CONFIG_PACKAGE_libzip-gnutls is not set
-# CONFIG_PACKAGE_libzip-mbedtls is not set
-# CONFIG_PACKAGE_libzip-nossl is not set
-# CONFIG_PACKAGE_libzip-openssl is not set
-# CONFIG_PACKAGE_libzstd is not set
 
 #
 # Filesystem
 #
-# CONFIG_PACKAGE_libacl is not set
-# CONFIG_PACKAGE_libattr is not set
 # CONFIG_PACKAGE_libfuse is not set
-# CONFIG_PACKAGE_libow is not set
-# CONFIG_PACKAGE_libow-capi is not set
 # CONFIG_PACKAGE_libsysfs is not set
 
 #
 # Firewall
 #
-# CONFIG_PACKAGE_libfko is not set
 CONFIG_PACKAGE_libip4tc=y
 CONFIG_PACKAGE_libip6tc=y
 # CONFIG_PACKAGE_libiptc is not set
@@ -3024,715 +2482,12 @@ CONFIG_PACKAGE_libxtables=y
 # CONFIG_PACKAGE_libxtables-nft is not set
 
 #
-# Instant Messaging
-#
-# CONFIG_PACKAGE_quasselc is not set
-
-#
-# IoT
-#
-# CONFIG_PACKAGE_libmraa is not set
-# CONFIG_PACKAGE_libmraa-python is not set
-# CONFIG_PACKAGE_libmraa-python3 is not set
-# CONFIG_PACKAGE_libupm-a110x is not set
-# CONFIG_PACKAGE_libupm-a110x-python is not set
-# CONFIG_PACKAGE_libupm-a110x-python3 is not set
-# CONFIG_PACKAGE_libupm-abp is not set
-# CONFIG_PACKAGE_libupm-abp-python is not set
-# CONFIG_PACKAGE_libupm-abp-python3 is not set
-# CONFIG_PACKAGE_libupm-ad8232 is not set
-# CONFIG_PACKAGE_libupm-ad8232-python is not set
-# CONFIG_PACKAGE_libupm-ad8232-python3 is not set
-# CONFIG_PACKAGE_libupm-adafruitms1438 is not set
-# CONFIG_PACKAGE_libupm-adafruitms1438-python is not set
-# CONFIG_PACKAGE_libupm-adafruitms1438-python3 is not set
-# CONFIG_PACKAGE_libupm-adafruitss is not set
-# CONFIG_PACKAGE_libupm-adafruitss-python is not set
-# CONFIG_PACKAGE_libupm-adafruitss-python3 is not set
-# CONFIG_PACKAGE_libupm-adc121c021 is not set
-# CONFIG_PACKAGE_libupm-adc121c021-python is not set
-# CONFIG_PACKAGE_libupm-adc121c021-python3 is not set
-# CONFIG_PACKAGE_libupm-adis16448 is not set
-# CONFIG_PACKAGE_libupm-adis16448-python is not set
-# CONFIG_PACKAGE_libupm-adis16448-python3 is not set
-# CONFIG_PACKAGE_libupm-ads1x15 is not set
-# CONFIG_PACKAGE_libupm-ads1x15-python is not set
-# CONFIG_PACKAGE_libupm-ads1x15-python3 is not set
-# CONFIG_PACKAGE_libupm-adxl335 is not set
-# CONFIG_PACKAGE_libupm-adxl335-python is not set
-# CONFIG_PACKAGE_libupm-adxl335-python3 is not set
-# CONFIG_PACKAGE_libupm-adxl345 is not set
-# CONFIG_PACKAGE_libupm-adxl345-python is not set
-# CONFIG_PACKAGE_libupm-adxl345-python3 is not set
-# CONFIG_PACKAGE_libupm-adxrs610 is not set
-# CONFIG_PACKAGE_libupm-adxrs610-python is not set
-# CONFIG_PACKAGE_libupm-adxrs610-python3 is not set
-# CONFIG_PACKAGE_libupm-am2315 is not set
-# CONFIG_PACKAGE_libupm-am2315-python is not set
-# CONFIG_PACKAGE_libupm-am2315-python3 is not set
-# CONFIG_PACKAGE_libupm-apa102 is not set
-# CONFIG_PACKAGE_libupm-apa102-python is not set
-# CONFIG_PACKAGE_libupm-apa102-python3 is not set
-# CONFIG_PACKAGE_libupm-apds9002 is not set
-# CONFIG_PACKAGE_libupm-apds9002-python is not set
-# CONFIG_PACKAGE_libupm-apds9002-python3 is not set
-# CONFIG_PACKAGE_libupm-apds9930 is not set
-# CONFIG_PACKAGE_libupm-apds9930-python is not set
-# CONFIG_PACKAGE_libupm-apds9930-python3 is not set
-# CONFIG_PACKAGE_libupm-at42qt1070 is not set
-# CONFIG_PACKAGE_libupm-at42qt1070-python is not set
-# CONFIG_PACKAGE_libupm-at42qt1070-python3 is not set
-# CONFIG_PACKAGE_libupm-bh1749 is not set
-# CONFIG_PACKAGE_libupm-bh1749-python is not set
-# CONFIG_PACKAGE_libupm-bh1749-python3 is not set
-# CONFIG_PACKAGE_libupm-bh1750 is not set
-# CONFIG_PACKAGE_libupm-bh1750-python is not set
-# CONFIG_PACKAGE_libupm-bh1750-python3 is not set
-# CONFIG_PACKAGE_libupm-bh1792 is not set
-# CONFIG_PACKAGE_libupm-bh1792-python is not set
-# CONFIG_PACKAGE_libupm-bh1792-python3 is not set
-# CONFIG_PACKAGE_libupm-biss0001 is not set
-# CONFIG_PACKAGE_libupm-biss0001-python is not set
-# CONFIG_PACKAGE_libupm-biss0001-python3 is not set
-# CONFIG_PACKAGE_libupm-bma220 is not set
-# CONFIG_PACKAGE_libupm-bma220-python is not set
-# CONFIG_PACKAGE_libupm-bma220-python3 is not set
-# CONFIG_PACKAGE_libupm-bma250e is not set
-# CONFIG_PACKAGE_libupm-bma250e-python is not set
-# CONFIG_PACKAGE_libupm-bma250e-python3 is not set
-# CONFIG_PACKAGE_libupm-bmg160 is not set
-# CONFIG_PACKAGE_libupm-bmg160-python is not set
-# CONFIG_PACKAGE_libupm-bmg160-python3 is not set
-# CONFIG_PACKAGE_libupm-bmi160 is not set
-# CONFIG_PACKAGE_libupm-bmi160-python is not set
-# CONFIG_PACKAGE_libupm-bmi160-python3 is not set
-# CONFIG_PACKAGE_libupm-bmm150 is not set
-# CONFIG_PACKAGE_libupm-bmm150-python is not set
-# CONFIG_PACKAGE_libupm-bmm150-python3 is not set
-# CONFIG_PACKAGE_libupm-bmp280 is not set
-# CONFIG_PACKAGE_libupm-bmp280-python is not set
-# CONFIG_PACKAGE_libupm-bmp280-python3 is not set
-# CONFIG_PACKAGE_libupm-bmpx8x is not set
-# CONFIG_PACKAGE_libupm-bmpx8x-python is not set
-# CONFIG_PACKAGE_libupm-bmpx8x-python3 is not set
-# CONFIG_PACKAGE_libupm-bmx055 is not set
-# CONFIG_PACKAGE_libupm-bmx055-python is not set
-# CONFIG_PACKAGE_libupm-bmx055-python3 is not set
-# CONFIG_PACKAGE_libupm-bno055 is not set
-# CONFIG_PACKAGE_libupm-bno055-python is not set
-# CONFIG_PACKAGE_libupm-bno055-python3 is not set
-# CONFIG_PACKAGE_libupm-button is not set
-# CONFIG_PACKAGE_libupm-button-python is not set
-# CONFIG_PACKAGE_libupm-button-python3 is not set
-# CONFIG_PACKAGE_libupm-buzzer is not set
-# CONFIG_PACKAGE_libupm-buzzer-python is not set
-# CONFIG_PACKAGE_libupm-buzzer-python3 is not set
-# CONFIG_PACKAGE_libupm-cjq4435 is not set
-# CONFIG_PACKAGE_libupm-cjq4435-python is not set
-# CONFIG_PACKAGE_libupm-cjq4435-python3 is not set
-# CONFIG_PACKAGE_libupm-collision is not set
-# CONFIG_PACKAGE_libupm-collision-python is not set
-# CONFIG_PACKAGE_libupm-collision-python3 is not set
-# CONFIG_PACKAGE_libupm-curieimu is not set
-# CONFIG_PACKAGE_libupm-curieimu-python is not set
-# CONFIG_PACKAGE_libupm-curieimu-python3 is not set
-# CONFIG_PACKAGE_libupm-cwlsxxa is not set
-# CONFIG_PACKAGE_libupm-cwlsxxa-python is not set
-# CONFIG_PACKAGE_libupm-cwlsxxa-python3 is not set
-# CONFIG_PACKAGE_libupm-dfrec is not set
-# CONFIG_PACKAGE_libupm-dfrec-python is not set
-# CONFIG_PACKAGE_libupm-dfrec-python3 is not set
-# CONFIG_PACKAGE_libupm-dfrorp is not set
-# CONFIG_PACKAGE_libupm-dfrorp-python is not set
-# CONFIG_PACKAGE_libupm-dfrorp-python3 is not set
-# CONFIG_PACKAGE_libupm-dfrph is not set
-# CONFIG_PACKAGE_libupm-dfrph-python is not set
-# CONFIG_PACKAGE_libupm-dfrph-python3 is not set
-# CONFIG_PACKAGE_libupm-ds1307 is not set
-# CONFIG_PACKAGE_libupm-ds1307-python is not set
-# CONFIG_PACKAGE_libupm-ds1307-python3 is not set
-# CONFIG_PACKAGE_libupm-ds1808lc is not set
-# CONFIG_PACKAGE_libupm-ds1808lc-python is not set
-# CONFIG_PACKAGE_libupm-ds1808lc-python3 is not set
-# CONFIG_PACKAGE_libupm-ds18b20 is not set
-# CONFIG_PACKAGE_libupm-ds18b20-python is not set
-# CONFIG_PACKAGE_libupm-ds18b20-python3 is not set
-# CONFIG_PACKAGE_libupm-ds2413 is not set
-# CONFIG_PACKAGE_libupm-ds2413-python is not set
-# CONFIG_PACKAGE_libupm-ds2413-python3 is not set
-# CONFIG_PACKAGE_libupm-ecezo is not set
-# CONFIG_PACKAGE_libupm-ecezo-python is not set
-# CONFIG_PACKAGE_libupm-ecezo-python3 is not set
-# CONFIG_PACKAGE_libupm-ecs1030 is not set
-# CONFIG_PACKAGE_libupm-ecs1030-python is not set
-# CONFIG_PACKAGE_libupm-ecs1030-python3 is not set
-# CONFIG_PACKAGE_libupm-ehr is not set
-# CONFIG_PACKAGE_libupm-ehr-python is not set
-# CONFIG_PACKAGE_libupm-ehr-python3 is not set
-# CONFIG_PACKAGE_libupm-eldriver is not set
-# CONFIG_PACKAGE_libupm-eldriver-python is not set
-# CONFIG_PACKAGE_libupm-eldriver-python3 is not set
-# CONFIG_PACKAGE_libupm-electromagnet is not set
-# CONFIG_PACKAGE_libupm-electromagnet-python is not set
-# CONFIG_PACKAGE_libupm-electromagnet-python3 is not set
-# CONFIG_PACKAGE_libupm-emg is not set
-# CONFIG_PACKAGE_libupm-emg-python is not set
-# CONFIG_PACKAGE_libupm-emg-python3 is not set
-# CONFIG_PACKAGE_libupm-enc03r is not set
-# CONFIG_PACKAGE_libupm-enc03r-python is not set
-# CONFIG_PACKAGE_libupm-enc03r-python3 is not set
-# CONFIG_PACKAGE_libupm-flex is not set
-# CONFIG_PACKAGE_libupm-flex-python is not set
-# CONFIG_PACKAGE_libupm-flex-python3 is not set
-# CONFIG_PACKAGE_libupm-gas is not set
-# CONFIG_PACKAGE_libupm-gas-python is not set
-# CONFIG_PACKAGE_libupm-gas-python3 is not set
-# CONFIG_PACKAGE_libupm-gp2y0a is not set
-# CONFIG_PACKAGE_libupm-gp2y0a-python is not set
-# CONFIG_PACKAGE_libupm-gp2y0a-python3 is not set
-# CONFIG_PACKAGE_libupm-gprs is not set
-# CONFIG_PACKAGE_libupm-gprs-python is not set
-# CONFIG_PACKAGE_libupm-gprs-python3 is not set
-# CONFIG_PACKAGE_libupm-grove is not set
-# CONFIG_PACKAGE_libupm-grove-python is not set
-# CONFIG_PACKAGE_libupm-grove-python3 is not set
-# CONFIG_PACKAGE_libupm-grovecollision is not set
-# CONFIG_PACKAGE_libupm-grovecollision-python is not set
-# CONFIG_PACKAGE_libupm-grovecollision-python3 is not set
-# CONFIG_PACKAGE_libupm-groveehr is not set
-# CONFIG_PACKAGE_libupm-groveehr-python is not set
-# CONFIG_PACKAGE_libupm-groveehr-python3 is not set
-# CONFIG_PACKAGE_libupm-groveeldriver is not set
-# CONFIG_PACKAGE_libupm-groveeldriver-python is not set
-# CONFIG_PACKAGE_libupm-groveeldriver-python3 is not set
-# CONFIG_PACKAGE_libupm-groveelectromagnet is not set
-# CONFIG_PACKAGE_libupm-groveelectromagnet-python is not set
-# CONFIG_PACKAGE_libupm-groveelectromagnet-python3 is not set
-# CONFIG_PACKAGE_libupm-groveemg is not set
-# CONFIG_PACKAGE_libupm-groveemg-python is not set
-# CONFIG_PACKAGE_libupm-groveemg-python3 is not set
-# CONFIG_PACKAGE_libupm-grovegprs is not set
-# CONFIG_PACKAGE_libupm-grovegprs-python is not set
-# CONFIG_PACKAGE_libupm-grovegprs-python3 is not set
-# CONFIG_PACKAGE_libupm-grovegsr is not set
-# CONFIG_PACKAGE_libupm-grovegsr-python is not set
-# CONFIG_PACKAGE_libupm-grovegsr-python3 is not set
-# CONFIG_PACKAGE_libupm-grovelinefinder is not set
-# CONFIG_PACKAGE_libupm-grovelinefinder-python is not set
-# CONFIG_PACKAGE_libupm-grovelinefinder-python3 is not set
-# CONFIG_PACKAGE_libupm-grovemd is not set
-# CONFIG_PACKAGE_libupm-grovemd-python is not set
-# CONFIG_PACKAGE_libupm-grovemd-python3 is not set
-# CONFIG_PACKAGE_libupm-grovemoisture is not set
-# CONFIG_PACKAGE_libupm-grovemoisture-python is not set
-# CONFIG_PACKAGE_libupm-grovemoisture-python3 is not set
-# CONFIG_PACKAGE_libupm-groveo2 is not set
-# CONFIG_PACKAGE_libupm-groveo2-python is not set
-# CONFIG_PACKAGE_libupm-groveo2-python3 is not set
-# CONFIG_PACKAGE_libupm-grovescam is not set
-# CONFIG_PACKAGE_libupm-grovescam-python is not set
-# CONFIG_PACKAGE_libupm-grovescam-python3 is not set
-# CONFIG_PACKAGE_libupm-grovespeaker is not set
-# CONFIG_PACKAGE_libupm-grovespeaker-python is not set
-# CONFIG_PACKAGE_libupm-grovespeaker-python3 is not set
-# CONFIG_PACKAGE_libupm-groveultrasonic is not set
-# CONFIG_PACKAGE_libupm-groveultrasonic-python is not set
-# CONFIG_PACKAGE_libupm-groveultrasonic-python3 is not set
-# CONFIG_PACKAGE_libupm-grovevdiv is not set
-# CONFIG_PACKAGE_libupm-grovevdiv-python is not set
-# CONFIG_PACKAGE_libupm-grovevdiv-python3 is not set
-# CONFIG_PACKAGE_libupm-grovewater is not set
-# CONFIG_PACKAGE_libupm-grovewater-python is not set
-# CONFIG_PACKAGE_libupm-grovewater-python3 is not set
-# CONFIG_PACKAGE_libupm-grovewfs is not set
-# CONFIG_PACKAGE_libupm-grovewfs-python is not set
-# CONFIG_PACKAGE_libupm-grovewfs-python3 is not set
-# CONFIG_PACKAGE_libupm-gsr is not set
-# CONFIG_PACKAGE_libupm-gsr-python is not set
-# CONFIG_PACKAGE_libupm-gsr-python3 is not set
-# CONFIG_PACKAGE_libupm-guvas12d is not set
-# CONFIG_PACKAGE_libupm-guvas12d-python is not set
-# CONFIG_PACKAGE_libupm-guvas12d-python3 is not set
-# CONFIG_PACKAGE_libupm-h3lis331dl is not set
-# CONFIG_PACKAGE_libupm-h3lis331dl-python is not set
-# CONFIG_PACKAGE_libupm-h3lis331dl-python3 is not set
-# CONFIG_PACKAGE_libupm-h803x is not set
-# CONFIG_PACKAGE_libupm-h803x-python is not set
-# CONFIG_PACKAGE_libupm-h803x-python3 is not set
-# CONFIG_PACKAGE_libupm-hcsr04 is not set
-# CONFIG_PACKAGE_libupm-hcsr04-python is not set
-# CONFIG_PACKAGE_libupm-hcsr04-python3 is not set
-# CONFIG_PACKAGE_libupm-hdc1000 is not set
-# CONFIG_PACKAGE_libupm-hdc1000-python is not set
-# CONFIG_PACKAGE_libupm-hdc1000-python3 is not set
-# CONFIG_PACKAGE_libupm-hdxxvxta is not set
-# CONFIG_PACKAGE_libupm-hdxxvxta-python is not set
-# CONFIG_PACKAGE_libupm-hdxxvxta-python3 is not set
-# CONFIG_PACKAGE_libupm-hka5 is not set
-# CONFIG_PACKAGE_libupm-hka5-python is not set
-# CONFIG_PACKAGE_libupm-hka5-python3 is not set
-# CONFIG_PACKAGE_libupm-hlg150h is not set
-# CONFIG_PACKAGE_libupm-hlg150h-python is not set
-# CONFIG_PACKAGE_libupm-hlg150h-python3 is not set
-# CONFIG_PACKAGE_libupm-hm11 is not set
-# CONFIG_PACKAGE_libupm-hm11-python is not set
-# CONFIG_PACKAGE_libupm-hm11-python3 is not set
-# CONFIG_PACKAGE_libupm-hmc5883l is not set
-# CONFIG_PACKAGE_libupm-hmc5883l-python is not set
-# CONFIG_PACKAGE_libupm-hmc5883l-python3 is not set
-# CONFIG_PACKAGE_libupm-hmtrp is not set
-# CONFIG_PACKAGE_libupm-hmtrp-python is not set
-# CONFIG_PACKAGE_libupm-hmtrp-python3 is not set
-# CONFIG_PACKAGE_libupm-hp20x is not set
-# CONFIG_PACKAGE_libupm-hp20x-python is not set
-# CONFIG_PACKAGE_libupm-hp20x-python3 is not set
-# CONFIG_PACKAGE_libupm-ht9170 is not set
-# CONFIG_PACKAGE_libupm-ht9170-python is not set
-# CONFIG_PACKAGE_libupm-ht9170-python3 is not set
-# CONFIG_PACKAGE_libupm-htu21d is not set
-# CONFIG_PACKAGE_libupm-htu21d-python is not set
-# CONFIG_PACKAGE_libupm-htu21d-python3 is not set
-# CONFIG_PACKAGE_libupm-hwxpxx is not set
-# CONFIG_PACKAGE_libupm-hwxpxx-python is not set
-# CONFIG_PACKAGE_libupm-hwxpxx-python3 is not set
-# CONFIG_PACKAGE_libupm-hx711 is not set
-# CONFIG_PACKAGE_libupm-hx711-python is not set
-# CONFIG_PACKAGE_libupm-hx711-python3 is not set
-# CONFIG_PACKAGE_libupm-ili9341 is not set
-# CONFIG_PACKAGE_libupm-ili9341-python is not set
-# CONFIG_PACKAGE_libupm-ili9341-python3 is not set
-# CONFIG_PACKAGE_libupm-ims is not set
-# CONFIG_PACKAGE_libupm-ims-python is not set
-# CONFIG_PACKAGE_libupm-ims-python3 is not set
-# CONFIG_PACKAGE_libupm-ina132 is not set
-# CONFIG_PACKAGE_libupm-ina132-python is not set
-# CONFIG_PACKAGE_libupm-ina132-python3 is not set
-# CONFIG_PACKAGE_libupm-interfaces is not set
-# CONFIG_PACKAGE_libupm-interfaces-python is not set
-# CONFIG_PACKAGE_libupm-interfaces-python3 is not set
-# CONFIG_PACKAGE_libupm-isd1820 is not set
-# CONFIG_PACKAGE_libupm-isd1820-python is not set
-# CONFIG_PACKAGE_libupm-isd1820-python3 is not set
-# CONFIG_PACKAGE_libupm-itg3200 is not set
-# CONFIG_PACKAGE_libupm-itg3200-python is not set
-# CONFIG_PACKAGE_libupm-itg3200-python3 is not set
-# CONFIG_PACKAGE_libupm-jhd1313m1 is not set
-# CONFIG_PACKAGE_libupm-jhd1313m1-python is not set
-# CONFIG_PACKAGE_libupm-jhd1313m1-python3 is not set
-# CONFIG_PACKAGE_libupm-joystick12 is not set
-# CONFIG_PACKAGE_libupm-joystick12-python is not set
-# CONFIG_PACKAGE_libupm-joystick12-python3 is not set
-# CONFIG_PACKAGE_libupm-kx122 is not set
-# CONFIG_PACKAGE_libupm-kx122-python is not set
-# CONFIG_PACKAGE_libupm-kx122-python3 is not set
-# CONFIG_PACKAGE_libupm-kxcjk1013 is not set
-# CONFIG_PACKAGE_libupm-kxcjk1013-python is not set
-# CONFIG_PACKAGE_libupm-kxcjk1013-python3 is not set
-# CONFIG_PACKAGE_libupm-kxtj3 is not set
-# CONFIG_PACKAGE_libupm-kxtj3-python is not set
-# CONFIG_PACKAGE_libupm-kxtj3-python3 is not set
-# CONFIG_PACKAGE_libupm-l298 is not set
-# CONFIG_PACKAGE_libupm-l298-python is not set
-# CONFIG_PACKAGE_libupm-l298-python3 is not set
-# CONFIG_PACKAGE_libupm-l3gd20 is not set
-# CONFIG_PACKAGE_libupm-l3gd20-python is not set
-# CONFIG_PACKAGE_libupm-l3gd20-python3 is not set
-# CONFIG_PACKAGE_libupm-lcd is not set
-# CONFIG_PACKAGE_libupm-lcd-python is not set
-# CONFIG_PACKAGE_libupm-lcd-python3 is not set
-# CONFIG_PACKAGE_libupm-lcdks is not set
-# CONFIG_PACKAGE_libupm-lcdks-python is not set
-# CONFIG_PACKAGE_libupm-lcdks-python3 is not set
-# CONFIG_PACKAGE_libupm-lcm1602 is not set
-# CONFIG_PACKAGE_libupm-lcm1602-python is not set
-# CONFIG_PACKAGE_libupm-lcm1602-python3 is not set
-# CONFIG_PACKAGE_libupm-ldt0028 is not set
-# CONFIG_PACKAGE_libupm-ldt0028-python is not set
-# CONFIG_PACKAGE_libupm-ldt0028-python3 is not set
-# CONFIG_PACKAGE_libupm-led is not set
-# CONFIG_PACKAGE_libupm-led-python is not set
-# CONFIG_PACKAGE_libupm-led-python3 is not set
-# CONFIG_PACKAGE_libupm-lidarlitev3 is not set
-# CONFIG_PACKAGE_libupm-lidarlitev3-python is not set
-# CONFIG_PACKAGE_libupm-lidarlitev3-python3 is not set
-# CONFIG_PACKAGE_libupm-light is not set
-# CONFIG_PACKAGE_libupm-light-python is not set
-# CONFIG_PACKAGE_libupm-light-python3 is not set
-# CONFIG_PACKAGE_libupm-linefinder is not set
-# CONFIG_PACKAGE_libupm-linefinder-python is not set
-# CONFIG_PACKAGE_libupm-linefinder-python3 is not set
-# CONFIG_PACKAGE_libupm-lis2ds12 is not set
-# CONFIG_PACKAGE_libupm-lis2ds12-python is not set
-# CONFIG_PACKAGE_libupm-lis2ds12-python3 is not set
-# CONFIG_PACKAGE_libupm-lis3dh is not set
-# CONFIG_PACKAGE_libupm-lis3dh-python is not set
-# CONFIG_PACKAGE_libupm-lis3dh-python3 is not set
-# CONFIG_PACKAGE_libupm-lm35 is not set
-# CONFIG_PACKAGE_libupm-lm35-python is not set
-# CONFIG_PACKAGE_libupm-lm35-python3 is not set
-# CONFIG_PACKAGE_libupm-lol is not set
-# CONFIG_PACKAGE_libupm-lol-python is not set
-# CONFIG_PACKAGE_libupm-lol-python3 is not set
-# CONFIG_PACKAGE_libupm-loudness is not set
-# CONFIG_PACKAGE_libupm-loudness-python is not set
-# CONFIG_PACKAGE_libupm-loudness-python3 is not set
-# CONFIG_PACKAGE_libupm-lp8860 is not set
-# CONFIG_PACKAGE_libupm-lp8860-python is not set
-# CONFIG_PACKAGE_libupm-lp8860-python3 is not set
-# CONFIG_PACKAGE_libupm-lpd8806 is not set
-# CONFIG_PACKAGE_libupm-lpd8806-python is not set
-# CONFIG_PACKAGE_libupm-lpd8806-python3 is not set
-# CONFIG_PACKAGE_libupm-lsm303agr is not set
-# CONFIG_PACKAGE_libupm-lsm303agr-python is not set
-# CONFIG_PACKAGE_libupm-lsm303agr-python3 is not set
-# CONFIG_PACKAGE_libupm-lsm303d is not set
-# CONFIG_PACKAGE_libupm-lsm303d-python is not set
-# CONFIG_PACKAGE_libupm-lsm303d-python3 is not set
-# CONFIG_PACKAGE_libupm-lsm303dlh is not set
-# CONFIG_PACKAGE_libupm-lsm303dlh-python is not set
-# CONFIG_PACKAGE_libupm-lsm303dlh-python3 is not set
-# CONFIG_PACKAGE_libupm-lsm6ds3h is not set
-# CONFIG_PACKAGE_libupm-lsm6ds3h-python is not set
-# CONFIG_PACKAGE_libupm-lsm6ds3h-python3 is not set
-# CONFIG_PACKAGE_libupm-lsm6dsl is not set
-# CONFIG_PACKAGE_libupm-lsm6dsl-python is not set
-# CONFIG_PACKAGE_libupm-lsm6dsl-python3 is not set
-# CONFIG_PACKAGE_libupm-lsm9ds0 is not set
-# CONFIG_PACKAGE_libupm-lsm9ds0-python is not set
-# CONFIG_PACKAGE_libupm-lsm9ds0-python3 is not set
-# CONFIG_PACKAGE_libupm-m24lr64e is not set
-# CONFIG_PACKAGE_libupm-m24lr64e-python is not set
-# CONFIG_PACKAGE_libupm-m24lr64e-python3 is not set
-# CONFIG_PACKAGE_libupm-mag3110 is not set
-# CONFIG_PACKAGE_libupm-mag3110-python is not set
-# CONFIG_PACKAGE_libupm-mag3110-python3 is not set
-# CONFIG_PACKAGE_libupm-max30100 is not set
-# CONFIG_PACKAGE_libupm-max30100-python is not set
-# CONFIG_PACKAGE_libupm-max30100-python3 is not set
-# CONFIG_PACKAGE_libupm-max31723 is not set
-# CONFIG_PACKAGE_libupm-max31723-python is not set
-# CONFIG_PACKAGE_libupm-max31723-python3 is not set
-# CONFIG_PACKAGE_libupm-max31855 is not set
-# CONFIG_PACKAGE_libupm-max31855-python is not set
-# CONFIG_PACKAGE_libupm-max31855-python3 is not set
-# CONFIG_PACKAGE_libupm-max44000 is not set
-# CONFIG_PACKAGE_libupm-max44000-python is not set
-# CONFIG_PACKAGE_libupm-max44000-python3 is not set
-# CONFIG_PACKAGE_libupm-max44009 is not set
-# CONFIG_PACKAGE_libupm-max44009-python is not set
-# CONFIG_PACKAGE_libupm-max44009-python3 is not set
-# CONFIG_PACKAGE_libupm-max5487 is not set
-# CONFIG_PACKAGE_libupm-max5487-python is not set
-# CONFIG_PACKAGE_libupm-max5487-python3 is not set
-# CONFIG_PACKAGE_libupm-maxds3231m is not set
-# CONFIG_PACKAGE_libupm-maxds3231m-python is not set
-# CONFIG_PACKAGE_libupm-maxds3231m-python3 is not set
-# CONFIG_PACKAGE_libupm-maxsonarez is not set
-# CONFIG_PACKAGE_libupm-maxsonarez-python is not set
-# CONFIG_PACKAGE_libupm-maxsonarez-python3 is not set
-# CONFIG_PACKAGE_libupm-mb704x is not set
-# CONFIG_PACKAGE_libupm-mb704x-python is not set
-# CONFIG_PACKAGE_libupm-mb704x-python3 is not set
-# CONFIG_PACKAGE_libupm-mcp2515 is not set
-# CONFIG_PACKAGE_libupm-mcp2515-python is not set
-# CONFIG_PACKAGE_libupm-mcp2515-python3 is not set
-# CONFIG_PACKAGE_libupm-mcp9808 is not set
-# CONFIG_PACKAGE_libupm-mcp9808-python is not set
-# CONFIG_PACKAGE_libupm-mcp9808-python3 is not set
-# CONFIG_PACKAGE_libupm-md is not set
-# CONFIG_PACKAGE_libupm-md-python is not set
-# CONFIG_PACKAGE_libupm-md-python3 is not set
-# CONFIG_PACKAGE_libupm-mg811 is not set
-# CONFIG_PACKAGE_libupm-mg811-python is not set
-# CONFIG_PACKAGE_libupm-mg811-python3 is not set
-# CONFIG_PACKAGE_libupm-mhz16 is not set
-# CONFIG_PACKAGE_libupm-mhz16-python is not set
-# CONFIG_PACKAGE_libupm-mhz16-python3 is not set
-# CONFIG_PACKAGE_libupm-mic is not set
-# CONFIG_PACKAGE_libupm-mic-python is not set
-# CONFIG_PACKAGE_libupm-mic-python3 is not set
-# CONFIG_PACKAGE_libupm-micsv89 is not set
-# CONFIG_PACKAGE_libupm-micsv89-python is not set
-# CONFIG_PACKAGE_libupm-micsv89-python3 is not set
-# CONFIG_PACKAGE_libupm-mlx90614 is not set
-# CONFIG_PACKAGE_libupm-mlx90614-python is not set
-# CONFIG_PACKAGE_libupm-mlx90614-python3 is not set
-# CONFIG_PACKAGE_libupm-mma7361 is not set
-# CONFIG_PACKAGE_libupm-mma7361-python is not set
-# CONFIG_PACKAGE_libupm-mma7361-python3 is not set
-# CONFIG_PACKAGE_libupm-mma7455 is not set
-# CONFIG_PACKAGE_libupm-mma7455-python is not set
-# CONFIG_PACKAGE_libupm-mma7455-python3 is not set
-# CONFIG_PACKAGE_libupm-mma7660 is not set
-# CONFIG_PACKAGE_libupm-mma7660-python is not set
-# CONFIG_PACKAGE_libupm-mma7660-python3 is not set
-# CONFIG_PACKAGE_libupm-mma8x5x is not set
-# CONFIG_PACKAGE_libupm-mma8x5x-python is not set
-# CONFIG_PACKAGE_libupm-mma8x5x-python3 is not set
-# CONFIG_PACKAGE_libupm-mmc35240 is not set
-# CONFIG_PACKAGE_libupm-mmc35240-python is not set
-# CONFIG_PACKAGE_libupm-mmc35240-python3 is not set
-# CONFIG_PACKAGE_libupm-moisture is not set
-# CONFIG_PACKAGE_libupm-moisture-python is not set
-# CONFIG_PACKAGE_libupm-moisture-python3 is not set
-# CONFIG_PACKAGE_libupm-mpl3115a2 is not set
-# CONFIG_PACKAGE_libupm-mpl3115a2-python is not set
-# CONFIG_PACKAGE_libupm-mpl3115a2-python3 is not set
-# CONFIG_PACKAGE_libupm-mpr121 is not set
-# CONFIG_PACKAGE_libupm-mpr121-python is not set
-# CONFIG_PACKAGE_libupm-mpr121-python3 is not set
-# CONFIG_PACKAGE_libupm-mpu9150 is not set
-# CONFIG_PACKAGE_libupm-mpu9150-python is not set
-# CONFIG_PACKAGE_libupm-mpu9150-python3 is not set
-# CONFIG_PACKAGE_libupm-mq303a is not set
-# CONFIG_PACKAGE_libupm-mq303a-python is not set
-# CONFIG_PACKAGE_libupm-mq303a-python3 is not set
-# CONFIG_PACKAGE_libupm-ms5611 is not set
-# CONFIG_PACKAGE_libupm-ms5611-python is not set
-# CONFIG_PACKAGE_libupm-ms5611-python3 is not set
-# CONFIG_PACKAGE_libupm-ms5803 is not set
-# CONFIG_PACKAGE_libupm-ms5803-python is not set
-# CONFIG_PACKAGE_libupm-ms5803-python3 is not set
-# CONFIG_PACKAGE_libupm-my9221 is not set
-# CONFIG_PACKAGE_libupm-my9221-python is not set
-# CONFIG_PACKAGE_libupm-my9221-python3 is not set
-# CONFIG_PACKAGE_libupm-nlgpio16 is not set
-# CONFIG_PACKAGE_libupm-nlgpio16-python is not set
-# CONFIG_PACKAGE_libupm-nlgpio16-python3 is not set
-# CONFIG_PACKAGE_libupm-nmea_gps is not set
-# CONFIG_PACKAGE_libupm-nmea_gps-python is not set
-# CONFIG_PACKAGE_libupm-nmea_gps-python3 is not set
-# CONFIG_PACKAGE_libupm-nrf24l01 is not set
-# CONFIG_PACKAGE_libupm-nrf24l01-python is not set
-# CONFIG_PACKAGE_libupm-nrf24l01-python3 is not set
-# CONFIG_PACKAGE_libupm-nrf8001 is not set
-# CONFIG_PACKAGE_libupm-nrf8001-python is not set
-# CONFIG_PACKAGE_libupm-nrf8001-python3 is not set
-# CONFIG_PACKAGE_libupm-nunchuck is not set
-# CONFIG_PACKAGE_libupm-nunchuck-python is not set
-# CONFIG_PACKAGE_libupm-nunchuck-python3 is not set
-# CONFIG_PACKAGE_libupm-o2 is not set
-# CONFIG_PACKAGE_libupm-o2-python is not set
-# CONFIG_PACKAGE_libupm-o2-python3 is not set
-# CONFIG_PACKAGE_libupm-otp538u is not set
-# CONFIG_PACKAGE_libupm-otp538u-python is not set
-# CONFIG_PACKAGE_libupm-otp538u-python3 is not set
-# CONFIG_PACKAGE_libupm-ozw is not set
-# CONFIG_PACKAGE_libupm-ozw-python is not set
-# CONFIG_PACKAGE_libupm-ozw-python3 is not set
-# CONFIG_PACKAGE_libupm-p9813 is not set
-# CONFIG_PACKAGE_libupm-p9813-python is not set
-# CONFIG_PACKAGE_libupm-p9813-python3 is not set
-# CONFIG_PACKAGE_libupm-pca9685 is not set
-# CONFIG_PACKAGE_libupm-pca9685-python is not set
-# CONFIG_PACKAGE_libupm-pca9685-python3 is not set
-# CONFIG_PACKAGE_libupm-pn532 is not set
-# CONFIG_PACKAGE_libupm-pn532-python is not set
-# CONFIG_PACKAGE_libupm-pn532-python3 is not set
-# CONFIG_PACKAGE_libupm-ppd42ns is not set
-# CONFIG_PACKAGE_libupm-ppd42ns-python is not set
-# CONFIG_PACKAGE_libupm-ppd42ns-python3 is not set
-# CONFIG_PACKAGE_libupm-pulsensor is not set
-# CONFIG_PACKAGE_libupm-pulsensor-python is not set
-# CONFIG_PACKAGE_libupm-pulsensor-python3 is not set
-# CONFIG_PACKAGE_libupm-relay is not set
-# CONFIG_PACKAGE_libupm-relay-python is not set
-# CONFIG_PACKAGE_libupm-relay-python3 is not set
-# CONFIG_PACKAGE_libupm-rf22 is not set
-# CONFIG_PACKAGE_libupm-rf22-python is not set
-# CONFIG_PACKAGE_libupm-rf22-python3 is not set
-# CONFIG_PACKAGE_libupm-rfr359f is not set
-# CONFIG_PACKAGE_libupm-rfr359f-python is not set
-# CONFIG_PACKAGE_libupm-rfr359f-python3 is not set
-# CONFIG_PACKAGE_libupm-rgbringcoder is not set
-# CONFIG_PACKAGE_libupm-rgbringcoder-python is not set
-# CONFIG_PACKAGE_libupm-rgbringcoder-python3 is not set
-# CONFIG_PACKAGE_libupm-rhusb is not set
-# CONFIG_PACKAGE_libupm-rhusb-python is not set
-# CONFIG_PACKAGE_libupm-rhusb-python3 is not set
-# CONFIG_PACKAGE_libupm-rn2903 is not set
-# CONFIG_PACKAGE_libupm-rn2903-python is not set
-# CONFIG_PACKAGE_libupm-rn2903-python3 is not set
-# CONFIG_PACKAGE_libupm-rotary is not set
-# CONFIG_PACKAGE_libupm-rotary-python is not set
-# CONFIG_PACKAGE_libupm-rotary-python3 is not set
-# CONFIG_PACKAGE_libupm-rotaryencoder is not set
-# CONFIG_PACKAGE_libupm-rotaryencoder-python is not set
-# CONFIG_PACKAGE_libupm-rotaryencoder-python3 is not set
-# CONFIG_PACKAGE_libupm-rpr220 is not set
-# CONFIG_PACKAGE_libupm-rpr220-python is not set
-# CONFIG_PACKAGE_libupm-rpr220-python3 is not set
-# CONFIG_PACKAGE_libupm-rsc is not set
-# CONFIG_PACKAGE_libupm-rsc-python is not set
-# CONFIG_PACKAGE_libupm-rsc-python3 is not set
-# CONFIG_PACKAGE_libupm-scam is not set
-# CONFIG_PACKAGE_libupm-scam-python is not set
-# CONFIG_PACKAGE_libupm-scam-python3 is not set
-# CONFIG_PACKAGE_libupm-sensortemplate is not set
-# CONFIG_PACKAGE_libupm-sensortemplate-python is not set
-# CONFIG_PACKAGE_libupm-sensortemplate-python3 is not set
-# CONFIG_PACKAGE_libupm-servo is not set
-# CONFIG_PACKAGE_libupm-servo-python is not set
-# CONFIG_PACKAGE_libupm-servo-python3 is not set
-# CONFIG_PACKAGE_libupm-sht1x is not set
-# CONFIG_PACKAGE_libupm-sht1x-python is not set
-# CONFIG_PACKAGE_libupm-sht1x-python3 is not set
-# CONFIG_PACKAGE_libupm-si1132 is not set
-# CONFIG_PACKAGE_libupm-si1132-python is not set
-# CONFIG_PACKAGE_libupm-si1132-python3 is not set
-# CONFIG_PACKAGE_libupm-si114x is not set
-# CONFIG_PACKAGE_libupm-si114x-python is not set
-# CONFIG_PACKAGE_libupm-si114x-python3 is not set
-# CONFIG_PACKAGE_libupm-si7005 is not set
-# CONFIG_PACKAGE_libupm-si7005-python is not set
-# CONFIG_PACKAGE_libupm-si7005-python3 is not set
-# CONFIG_PACKAGE_libupm-slide is not set
-# CONFIG_PACKAGE_libupm-slide-python is not set
-# CONFIG_PACKAGE_libupm-slide-python3 is not set
-# CONFIG_PACKAGE_libupm-sm130 is not set
-# CONFIG_PACKAGE_libupm-sm130-python is not set
-# CONFIG_PACKAGE_libupm-sm130-python3 is not set
-# CONFIG_PACKAGE_libupm-smartdrive is not set
-# CONFIG_PACKAGE_libupm-smartdrive-python is not set
-# CONFIG_PACKAGE_libupm-smartdrive-python3 is not set
-# CONFIG_PACKAGE_libupm-speaker is not set
-# CONFIG_PACKAGE_libupm-speaker-python is not set
-# CONFIG_PACKAGE_libupm-speaker-python3 is not set
-# CONFIG_PACKAGE_libupm-ssd1351 is not set
-# CONFIG_PACKAGE_libupm-ssd1351-python is not set
-# CONFIG_PACKAGE_libupm-ssd1351-python3 is not set
-# CONFIG_PACKAGE_libupm-st7735 is not set
-# CONFIG_PACKAGE_libupm-st7735-python is not set
-# CONFIG_PACKAGE_libupm-st7735-python3 is not set
-# CONFIG_PACKAGE_libupm-stepmotor is not set
-# CONFIG_PACKAGE_libupm-stepmotor-python is not set
-# CONFIG_PACKAGE_libupm-stepmotor-python3 is not set
-# CONFIG_PACKAGE_libupm-sx1276 is not set
-# CONFIG_PACKAGE_libupm-sx1276-python is not set
-# CONFIG_PACKAGE_libupm-sx1276-python3 is not set
-# CONFIG_PACKAGE_libupm-sx6119 is not set
-# CONFIG_PACKAGE_libupm-sx6119-python is not set
-# CONFIG_PACKAGE_libupm-sx6119-python3 is not set
-# CONFIG_PACKAGE_libupm-t3311 is not set
-# CONFIG_PACKAGE_libupm-t3311-python is not set
-# CONFIG_PACKAGE_libupm-t3311-python3 is not set
-# CONFIG_PACKAGE_libupm-t6713 is not set
-# CONFIG_PACKAGE_libupm-t6713-python is not set
-# CONFIG_PACKAGE_libupm-t6713-python3 is not set
-# CONFIG_PACKAGE_libupm-ta12200 is not set
-# CONFIG_PACKAGE_libupm-ta12200-python is not set
-# CONFIG_PACKAGE_libupm-ta12200-python3 is not set
-# CONFIG_PACKAGE_libupm-tca9548a is not set
-# CONFIG_PACKAGE_libupm-tca9548a-python is not set
-# CONFIG_PACKAGE_libupm-tca9548a-python3 is not set
-# CONFIG_PACKAGE_libupm-tcs3414cs is not set
-# CONFIG_PACKAGE_libupm-tcs3414cs-python is not set
-# CONFIG_PACKAGE_libupm-tcs3414cs-python3 is not set
-# CONFIG_PACKAGE_libupm-tcs37727 is not set
-# CONFIG_PACKAGE_libupm-tcs37727-python is not set
-# CONFIG_PACKAGE_libupm-tcs37727-python3 is not set
-# CONFIG_PACKAGE_libupm-teams is not set
-# CONFIG_PACKAGE_libupm-teams-python is not set
-# CONFIG_PACKAGE_libupm-teams-python3 is not set
-# CONFIG_PACKAGE_libupm-temperature is not set
-# CONFIG_PACKAGE_libupm-temperature-python is not set
-# CONFIG_PACKAGE_libupm-temperature-python3 is not set
-# CONFIG_PACKAGE_libupm-tex00 is not set
-# CONFIG_PACKAGE_libupm-tex00-python is not set
-# CONFIG_PACKAGE_libupm-tex00-python3 is not set
-# CONFIG_PACKAGE_libupm-th02 is not set
-# CONFIG_PACKAGE_libupm-th02-python is not set
-# CONFIG_PACKAGE_libupm-th02-python3 is not set
-# CONFIG_PACKAGE_libupm-tm1637 is not set
-# CONFIG_PACKAGE_libupm-tm1637-python is not set
-# CONFIG_PACKAGE_libupm-tm1637-python3 is not set
-# CONFIG_PACKAGE_libupm-tmp006 is not set
-# CONFIG_PACKAGE_libupm-tmp006-python is not set
-# CONFIG_PACKAGE_libupm-tmp006-python3 is not set
-# CONFIG_PACKAGE_libupm-tsl2561 is not set
-# CONFIG_PACKAGE_libupm-tsl2561-python is not set
-# CONFIG_PACKAGE_libupm-tsl2561-python3 is not set
-# CONFIG_PACKAGE_libupm-ttp223 is not set
-# CONFIG_PACKAGE_libupm-ttp223-python is not set
-# CONFIG_PACKAGE_libupm-ttp223-python3 is not set
-# CONFIG_PACKAGE_libupm-uartat is not set
-# CONFIG_PACKAGE_libupm-uartat-python is not set
-# CONFIG_PACKAGE_libupm-uartat-python3 is not set
-# CONFIG_PACKAGE_libupm-uln200xa is not set
-# CONFIG_PACKAGE_libupm-uln200xa-python is not set
-# CONFIG_PACKAGE_libupm-uln200xa-python3 is not set
-# CONFIG_PACKAGE_libupm-ultrasonic is not set
-# CONFIG_PACKAGE_libupm-ultrasonic-python is not set
-# CONFIG_PACKAGE_libupm-ultrasonic-python3 is not set
-# CONFIG_PACKAGE_libupm-urm37 is not set
-# CONFIG_PACKAGE_libupm-urm37-python is not set
-# CONFIG_PACKAGE_libupm-urm37-python3 is not set
-# CONFIG_PACKAGE_libupm-utilities is not set
-# CONFIG_PACKAGE_libupm-utilities-python is not set
-# CONFIG_PACKAGE_libupm-utilities-python3 is not set
-# CONFIG_PACKAGE_libupm-vcap is not set
-# CONFIG_PACKAGE_libupm-vcap-python is not set
-# CONFIG_PACKAGE_libupm-vcap-python3 is not set
-# CONFIG_PACKAGE_libupm-vdiv is not set
-# CONFIG_PACKAGE_libupm-vdiv-python is not set
-# CONFIG_PACKAGE_libupm-vdiv-python3 is not set
-# CONFIG_PACKAGE_libupm-veml6070 is not set
-# CONFIG_PACKAGE_libupm-veml6070-python is not set
-# CONFIG_PACKAGE_libupm-veml6070-python3 is not set
-# CONFIG_PACKAGE_libupm-water is not set
-# CONFIG_PACKAGE_libupm-water-python is not set
-# CONFIG_PACKAGE_libupm-water-python3 is not set
-# CONFIG_PACKAGE_libupm-waterlevel is not set
-# CONFIG_PACKAGE_libupm-waterlevel-python is not set
-# CONFIG_PACKAGE_libupm-waterlevel-python3 is not set
-# CONFIG_PACKAGE_libupm-wfs is not set
-# CONFIG_PACKAGE_libupm-wfs-python is not set
-# CONFIG_PACKAGE_libupm-wfs-python3 is not set
-# CONFIG_PACKAGE_libupm-wheelencoder is not set
-# CONFIG_PACKAGE_libupm-wheelencoder-python is not set
-# CONFIG_PACKAGE_libupm-wheelencoder-python3 is not set
-# CONFIG_PACKAGE_libupm-wt5001 is not set
-# CONFIG_PACKAGE_libupm-wt5001-python is not set
-# CONFIG_PACKAGE_libupm-wt5001-python3 is not set
-# CONFIG_PACKAGE_libupm-xbee is not set
-# CONFIG_PACKAGE_libupm-xbee-python is not set
-# CONFIG_PACKAGE_libupm-xbee-python3 is not set
-# CONFIG_PACKAGE_libupm-yg1006 is not set
-# CONFIG_PACKAGE_libupm-yg1006-python is not set
-# CONFIG_PACKAGE_libupm-yg1006-python3 is not set
-# CONFIG_PACKAGE_libupm-zfm20 is not set
-# CONFIG_PACKAGE_libupm-zfm20-python is not set
-# CONFIG_PACKAGE_libupm-zfm20-python3 is not set
-
-#
-# Languages
-#
-# CONFIG_PACKAGE_libyaml is not set
-
-#
-# Networking
-#
-# CONFIG_PACKAGE_libdcwproto is not set
-# CONFIG_PACKAGE_libdcwsocket is not set
-# CONFIG_PACKAGE_libsctp is not set
-# CONFIG_PACKAGE_libuhttpd-mbedtls is not set
-# CONFIG_PACKAGE_libuhttpd-nossl is not set
-# CONFIG_PACKAGE_libuhttpd-openssl is not set
-# CONFIG_PACKAGE_libuhttpd-wolfssl is not set
-# CONFIG_PACKAGE_libunbound-heavy is not set
-# CONFIG_PACKAGE_libunbound-light is not set
-# CONFIG_PACKAGE_libuwsc-mbedtls is not set
-# CONFIG_PACKAGE_libuwsc-nossl is not set
-# CONFIG_PACKAGE_libuwsc-openssl is not set
-# CONFIG_PACKAGE_libuwsc-wolfssl is not set
-
-#
 # Qt5
 #
 # CONFIG_PACKAGE_qt5-concurrent is not set
-# CONFIG_PACKAGE_qt5-core is not set
-# CONFIG_PACKAGE_qt5-network is not set
-# CONFIG_PACKAGE_qt5-sql is not set
+CONFIG_PACKAGE_qt5-core=y
+CONFIG_PACKAGE_qt5-network=y
+CONFIG_PACKAGE_qt5-sql=y
 # CONFIG_PACKAGE_qt5-test is not set
 # CONFIG_PACKAGE_qt5-widgets is not set
 # CONFIG_PACKAGE_qt5-xml is not set
@@ -3741,277 +2496,55 @@ CONFIG_PACKAGE_libxtables=y
 #
 # SSL
 #
-# CONFIG_PACKAGE_libbotan is not set
-# CONFIG_PACKAGE_libgnutls is not set
 # CONFIG_PACKAGE_libmbedtls is not set
-# CONFIG_PACKAGE_libnss is not set
 # CONFIG_PACKAGE_libopenssl is not set
 # CONFIG_PACKAGE_libwolfssl is not set
-
-#
-# Sound
-#
-# CONFIG_PACKAGE_liblo is not set
-
-#
-# Telephony
-#
-# CONFIG_PACKAGE_bcg729 is not set
-# CONFIG_PACKAGE_dahdi-tools-libtonezone is not set
-# CONFIG_PACKAGE_gsmlib is not set
-# CONFIG_PACKAGE_libctb is not set
-# CONFIG_PACKAGE_libfreetdm is not set
-# CONFIG_PACKAGE_libiksemel is not set
-# CONFIG_PACKAGE_libks is not set
-# CONFIG_PACKAGE_libosip2 is not set
-# CONFIG_PACKAGE_libpj is not set
-# CONFIG_PACKAGE_libpjlib-util is not set
-# CONFIG_PACKAGE_libpjmedia is not set
-# CONFIG_PACKAGE_libpjnath is not set
-# CONFIG_PACKAGE_libpjsip is not set
-# CONFIG_PACKAGE_libpjsip-simple is not set
-# CONFIG_PACKAGE_libpjsip-ua is not set
-# CONFIG_PACKAGE_libpjsua is not set
-# CONFIG_PACKAGE_libpjsua2 is not set
-# CONFIG_PACKAGE_libre is not set
-# CONFIG_PACKAGE_librem is not set
-# CONFIG_PACKAGE_libspandsp is not set
-# CONFIG_PACKAGE_libspandsp3 is not set
-# CONFIG_PACKAGE_libsrtp is not set
-# CONFIG_PACKAGE_libsrtp2 is not set
-# CONFIG_PACKAGE_signalwire-client-c is not set
-# CONFIG_PACKAGE_sofia-sip is not set
-
-#
-# database
-#
-# CONFIG_PACKAGE_libpq is not set
-# CONFIG_PACKAGE_libsqlite3 is not set
-# CONFIG_PACKAGE_pgsqlodbc is not set
-# CONFIG_PACKAGE_psqlodbca is not set
-# CONFIG_PACKAGE_psqlodbcw is not set
-# CONFIG_PACKAGE_tdb is not set
-# CONFIG_PACKAGE_unixodbc is not set
-
-#
-# libelektra
-#
-# CONFIG_PACKAGE_libelektra-boost is not set
-# CONFIG_PACKAGE_libelektra-core is not set
-# CONFIG_PACKAGE_libelektra-cpp is not set
-# CONFIG_PACKAGE_libelektra-crypto is not set
-# CONFIG_PACKAGE_libelektra-curlget is not set
-# CONFIG_PACKAGE_libelektra-dbus is not set
-# CONFIG_PACKAGE_libelektra-extra is not set
-# CONFIG_PACKAGE_libelektra-lua is not set
-# CONFIG_PACKAGE_libelektra-plugins is not set
-# CONFIG_PACKAGE_libelektra-python2 is not set
-# CONFIG_PACKAGE_libelektra-python3 is not set
-# CONFIG_PACKAGE_libelektra-resolvers is not set
-# CONFIG_PACKAGE_libelektra-xerces is not set
-# CONFIG_PACKAGE_libelektra-xml is not set
-# CONFIG_PACKAGE_libelektra-yajl is not set
-# CONFIG_PACKAGE_libelektra-yamlcpp is not set
-
-#
-# libimobiledevice
-#
-# CONFIG_PACKAGE_libimobiledevice is not set
-# CONFIG_PACKAGE_libirecovery is not set
-# CONFIG_PACKAGE_libplist is not set
-# CONFIG_PACKAGE_libplistcxx is not set
-# CONFIG_PACKAGE_libusbmuxd is not set
-# CONFIG_PACKAGE_alsa-lib is not set
 # CONFIG_PACKAGE_argp-standalone is not set
-# CONFIG_PACKAGE_avro-c is not set
-# CONFIG_PACKAGE_bind-libs is not set
-# CONFIG_PACKAGE_bluez-libs is not set
-# CONFIG_PACKAGE_boost is not set
-# CONFIG_boost-context-exclude is not set
-# CONFIG_boost-coroutine-exclude is not set
-# CONFIG_boost-fiber-exclude is not set
-# CONFIG_PACKAGE_ccid is not set
-# CONFIG_PACKAGE_check is not set
-# CONFIG_PACKAGE_classpath is not set
-# CONFIG_PACKAGE_classpath-tools is not set
-# CONFIG_PACKAGE_confuse is not set
-# CONFIG_PACKAGE_czmq is not set
-# CONFIG_PACKAGE_dtndht is not set
-# CONFIG_PACKAGE_fbthrift is not set
-# CONFIG_PACKAGE_fbzmq is not set
-# CONFIG_PACKAGE_fcgi is not set
-# CONFIG_PACKAGE_fftw3 is not set
-# CONFIG_PACKAGE_fftw3f is not set
-# CONFIG_PACKAGE_fftw3l is not set
-# CONFIG_PACKAGE_getdns is not set
-# CONFIG_PACKAGE_gflags is not set
-# CONFIG_PACKAGE_giflib is not set
-# CONFIG_PACKAGE_glib2 is not set
-# CONFIG_PACKAGE_glog is not set
-# CONFIG_PACKAGE_google-authenticator-libpam is not set
 # CONFIG_PACKAGE_hidapi is not set
-# CONFIG_PACKAGE_ibrcommon is not set
-# CONFIG_PACKAGE_ibrdtn is not set
-# CONFIG_PACKAGE_icu is not set
-# CONFIG_PACKAGE_icu-data-tools is not set
-# CONFIG_PACKAGE_icu-full-data is not set
-# CONFIG_PACKAGE_jansson is not set
-# CONFIG_PACKAGE_jsoncpp is not set
-# CONFIG_PACKAGE_knot-libs is not set
-# CONFIG_PACKAGE_knot-libzscanner is not set
-# CONFIG_PACKAGE_libaio is not set
-# CONFIG_PACKAGE_libantlr3c is not set
-# CONFIG_PACKAGE_libao is not set
-# CONFIG_PACKAGE_libapr is not set
-# CONFIG_PACKAGE_libaprutil is not set
-# CONFIG_PACKAGE_libarchive is not set
-# CONFIG_PACKAGE_libarchive-noopenssl is not set
-# CONFIG_PACKAGE_libartnet is not set
 # CONFIG_PACKAGE_libasm is not set
-# CONFIG_PACKAGE_libaudiofile is not set
-# CONFIG_PACKAGE_libavahi-client is not set
-# CONFIG_PACKAGE_libavahi-compat-libdnssd is not set
-# CONFIG_PACKAGE_libavahi-dbus-support is not set
-# CONFIG_PACKAGE_libavahi-nodbus-support is not set
-# CONFIG_PACKAGE_libavl is not set
 # CONFIG_PACKAGE_libbfd is not set
 # CONFIG_PACKAGE_libblkid is not set
 CONFIG_PACKAGE_libblobmsg-json=y
 # CONFIG_PACKAGE_libbsd is not set
-# CONFIG_PACKAGE_libcanfestival is not set
-# CONFIG_PACKAGE_libcap is not set
-# CONFIG_PACKAGE_libcares is not set
-# CONFIG_PACKAGE_libcgroup is not set
 # CONFIG_PACKAGE_libcharset is not set
-# CONFIG_PACKAGE_libcoap is not set
 # CONFIG_PACKAGE_libcomerr is not set
 # CONFIG_PACKAGE_libconfig is not set
 # CONFIG_PACKAGE_libcurl is not set
-# CONFIG_PACKAGE_libdaemon is not set
-# CONFIG_PACKAGE_libdaq is not set
-# CONFIG_PACKAGE_libdaq3 is not set
-# CONFIG_PACKAGE_libdb47 is not set
-# CONFIG_PACKAGE_libdb47xx is not set
-# CONFIG_PACKAGE_libdbi is not set
-# CONFIG_PACKAGE_libdbus is not set
-# CONFIG_PACKAGE_libdevmapper is not set
-# CONFIG_PACKAGE_libdmapsharing is not set
-# CONFIG_PACKAGE_libdnet is not set
-# CONFIG_PACKAGE_libdouble-conversion is not set
-# CONFIG_PACKAGE_libdrm is not set
 # CONFIG_PACKAGE_libdw is not set
-# CONFIG_PACKAGE_libecdsautil is not set
-# CONFIG_PACKAGE_libedit is not set
 # CONFIG_PACKAGE_libelf is not set
-# CONFIG_PACKAGE_libesmtp is not set
-# CONFIG_PACKAGE_libestr is not set
-# CONFIG_PACKAGE_libev is not set
-# CONFIG_PACKAGE_libevdev is not set
 # CONFIG_PACKAGE_libevent2 is not set
 # CONFIG_PACKAGE_libevent2-core is not set
 # CONFIG_PACKAGE_libevent2-extra is not set
 # CONFIG_PACKAGE_libevent2-openssl is not set
 # CONFIG_PACKAGE_libevent2-pthreads is not set
-# CONFIG_PACKAGE_libexif is not set
-# CONFIG_PACKAGE_libexpat is not set
-# CONFIG_PACKAGE_libexslt is not set
 # CONFIG_PACKAGE_libext2fs is not set
-# CONFIG_PACKAGE_libextractor is not set
 # CONFIG_PACKAGE_libf2fs is not set
-# CONFIG_PACKAGE_libfaad2 is not set
-# CONFIG_PACKAGE_libfastjson is not set
 # CONFIG_PACKAGE_libfdisk is not set
-# CONFIG_PACKAGE_libfdt is not set
-# CONFIG_PACKAGE_libffi is not set
 # CONFIG_PACKAGE_libffmpeg-audio-dec is not set
 # CONFIG_PACKAGE_libffmpeg-custom is not set
 # CONFIG_PACKAGE_libffmpeg-full is not set
 # CONFIG_PACKAGE_libffmpeg-mini is not set
-# CONFIG_PACKAGE_libfizz is not set
-# CONFIG_PACKAGE_libflac is not set
-# CONFIG_PACKAGE_libfmt is not set
-# CONFIG_PACKAGE_libfolly is not set
-# CONFIG_PACKAGE_libfreetype is not set
-# CONFIG_PACKAGE_libfstrm is not set
-# CONFIG_PACKAGE_libftdi is not set
 # CONFIG_PACKAGE_libftdi1 is not set
-# CONFIG_PACKAGE_libgabe is not set
-# CONFIG_PACKAGE_libgcrypt is not set
-# CONFIG_PACKAGE_libgd is not set
-# CONFIG_PACKAGE_libgdbm is not set
-# CONFIG_PACKAGE_libgee is not set
-# CONFIG_PACKAGE_libglpk is not set
 # CONFIG_PACKAGE_libgmp is not set
-# CONFIG_PACKAGE_libgnurl is not set
-# CONFIG_PACKAGE_libgpg-error is not set
-# CONFIG_PACKAGE_libgphoto2 is not set
-# CONFIG_PACKAGE_libgpiod is not set
-# CONFIG_PACKAGE_libgps is not set
-# CONFIG_PACKAGE_libhamlib is not set
-# CONFIG_PACKAGE_libhavege is not set
-# CONFIG_PACKAGE_libhiredis is not set
-# CONFIG_PACKAGE_libhttp-parser is not set
-# CONFIG_PACKAGE_libhwloc is not set
-# CONFIG_PACKAGE_libi2c is not set
-# CONFIG_PACKAGE_libical is not set
 # CONFIG_PACKAGE_libiconv is not set
 # CONFIG_PACKAGE_libiconv-full is not set
-# CONFIG_PACKAGE_libid3tag is not set
-# CONFIG_PACKAGE_libidn is not set
-# CONFIG_PACKAGE_libidn2 is not set
-# CONFIG_PACKAGE_libiio is not set
-# CONFIG_PACKAGE_libinotifytools is not set
-# CONFIG_PACKAGE_libinput is not set
 # CONFIG_PACKAGE_libintl is not set
 # CONFIG_PACKAGE_libintl-full is not set
 # CONFIG_PACKAGE_libiw is not set
 CONFIG_PACKAGE_libiwinfo=y
-# CONFIG_PACKAGE_libjpeg is not set
 CONFIG_PACKAGE_libjson-c=y
-# CONFIG_PACKAGE_libkeyutils is not set
-# CONFIG_PACKAGE_libkmod is not set
-# CONFIG_PACKAGE_libldns is not set
-# CONFIG_PACKAGE_libloragw is not set
 # CONFIG_PACKAGE_libltdl is not set
 # CONFIG_PACKAGE_liblua is not set
-# CONFIG_PACKAGE_liblucihttp is not set
-# CONFIG_PACKAGE_liblucihttp-lua is not set
 # CONFIG_PACKAGE_liblzo is not set
-# CONFIG_PACKAGE_libmad is not set
-# CONFIG_PACKAGE_libmagic is not set
-# CONFIG_PACKAGE_libmariadb is not set
-# CONFIG_PACKAGE_libmaxminddb is not set
-# CONFIG_PACKAGE_libmbim is not set
-# CONFIG_PACKAGE_libmcrypt is not set
-# CONFIG_PACKAGE_libmicrohttpd-no-ssl is not set
-# CONFIG_PACKAGE_libmicrohttpd-ssl is not set
-# CONFIG_PACKAGE_libmilter-sendmail is not set
-# CONFIG_PACKAGE_libminiupnpc is not set
-# CONFIG_PACKAGE_libmms is not set
 # CONFIG_PACKAGE_libmnl is not set
-# CONFIG_PACKAGE_libmodbus is not set
-# CONFIG_PACKAGE_libmosquitto-nossl is not set
-# CONFIG_PACKAGE_libmosquitto-ssl is not set
 # CONFIG_PACKAGE_libmount is not set
-# CONFIG_PACKAGE_libmpdclient is not set
-# CONFIG_PACKAGE_libmpeg2 is not set
-# CONFIG_PACKAGE_libmpg123 is not set
-# CONFIG_PACKAGE_libmstch is not set
-# CONFIG_PACKAGE_libnatpmp is not set
 # CONFIG_PACKAGE_libncurses is not set
-# CONFIG_PACKAGE_libndpi is not set
-# CONFIG_PACKAGE_libneon is not set
-# CONFIG_PACKAGE_libnet-1.2.x is not set
-# CONFIG_PACKAGE_libnetconf2 is not set
-# CONFIG_PACKAGE_libnetfilter-acct is not set
 # CONFIG_PACKAGE_libnetfilter-conntrack is not set
 # CONFIG_PACKAGE_libnetfilter-cthelper is not set
 # CONFIG_PACKAGE_libnetfilter-cttimeout is not set
 # CONFIG_PACKAGE_libnetfilter-log is not set
 # CONFIG_PACKAGE_libnetfilter-queue is not set
-# CONFIG_PACKAGE_libnetsnmp is not set
 # CONFIG_PACKAGE_libnettle is not set
-# CONFIG_PACKAGE_libnewt is not set
 # CONFIG_PACKAGE_libnfnetlink is not set
 # CONFIG_PACKAGE_libnftnl is not set
 # CONFIG_PACKAGE_libnghttp2 is not set
@@ -4021,107 +2554,16 @@ CONFIG_PACKAGE_libjson-c=y
 # CONFIG_PACKAGE_libnl-nf is not set
 # CONFIG_PACKAGE_libnl-route is not set
 CONFIG_PACKAGE_libnl-tiny=y
-# CONFIG_PACKAGE_libnopoll is not set
-# CONFIG_PACKAGE_libogg is not set
-# CONFIG_PACKAGE_liboil is not set
 # CONFIG_PACKAGE_libopcodes is not set
-# CONFIG_PACKAGE_libopendkim is not set
-# CONFIG_PACKAGE_libopenobex is not set
-# CONFIG_PACKAGE_libopensc is not set
-# CONFIG_PACKAGE_libopenzwave is not set
-# CONFIG_PACKAGE_liboping is not set
-# CONFIG_PACKAGE_libopus is not set
-# CONFIG_PACKAGE_libopusenc is not set
-# CONFIG_PACKAGE_libopusfile is not set
-# CONFIG_PACKAGE_libout123 is not set
-# CONFIG_PACKAGE_libp11 is not set
-# CONFIG_PACKAGE_libpagekite is not set
-# CONFIG_PACKAGE_libpam is not set
-# CONFIG_PACKAGE_libpbc is not set
 # CONFIG_PACKAGE_libpcap is not set
-# CONFIG_PACKAGE_libpci is not set
-# CONFIG_PACKAGE_libpciaccess is not set
-# CONFIG_PACKAGE_libpcre is not set
-# CONFIG_PACKAGE_libpcre16 is not set
-# CONFIG_PACKAGE_libpcre2 is not set
-# CONFIG_PACKAGE_libpcre2-16 is not set
-# CONFIG_PACKAGE_libpcre2-32 is not set
-# CONFIG_PACKAGE_libpcrecpp is not set
-# CONFIG_PACKAGE_libpcsclite is not set
-# CONFIG_PACKAGE_libpfring is not set
-# CONFIG_PACKAGE_libpkcs11-spy is not set
-# CONFIG_PACKAGE_libpng is not set
 # CONFIG_PACKAGE_libpopt is not set
-# CONFIG_PACKAGE_libpri is not set
-# CONFIG_PACKAGE_libprotobuf-c is not set
-# CONFIG_PACKAGE_libpsl is not set
-# CONFIG_PACKAGE_libqmi is not set
-# CONFIG_PACKAGE_libqrencode is not set
-# CONFIG_PACKAGE_libradcli is not set
 # CONFIG_PACKAGE_libreadline is not set
-# CONFIG_PACKAGE_libredblack is not set
-# CONFIG_PACKAGE_librouteros is not set
 # CONFIG_PACKAGE_libroxml is not set
-# CONFIG_PACKAGE_librrd1 is not set
-# CONFIG_PACKAGE_librsocket-cpp is not set
-# CONFIG_PACKAGE_librtlsdr is not set
-# CONFIG_PACKAGE_libruby is not set
-# CONFIG_PACKAGE_libsamplerate is not set
-# CONFIG_PACKAGE_libsane is not set
-# CONFIG_PACKAGE_libsasl2 is not set
 # CONFIG_PACKAGE_libsdl is not set
-# CONFIG_PACKAGE_libsearpc is not set
-# CONFIG_PACKAGE_libseccomp is not set
-# CONFIG_PACKAGE_libsensors is not set
 # CONFIG_PACKAGE_libserialport is not set
-# CONFIG_PACKAGE_libshout is not set
-# CONFIG_PACKAGE_libshout-full is not set
-# CONFIG_PACKAGE_libshout-nossl is not set
-# CONFIG_PACKAGE_libsigar is not set
-# CONFIG_PACKAGE_libsispmctl is not set
-# CONFIG_PACKAGE_libslang2 is not set
-# CONFIG_PACKAGE_libslang2-mod-base64 is not set
-# CONFIG_PACKAGE_libslang2-mod-chksum is not set
-# CONFIG_PACKAGE_libslang2-mod-csv is not set
-# CONFIG_PACKAGE_libslang2-mod-fcntl is not set
-# CONFIG_PACKAGE_libslang2-mod-fork is not set
-# CONFIG_PACKAGE_libslang2-mod-histogram is not set
-# CONFIG_PACKAGE_libslang2-mod-iconv is not set
-# CONFIG_PACKAGE_libslang2-mod-json is not set
-# CONFIG_PACKAGE_libslang2-mod-onig is not set
-# CONFIG_PACKAGE_libslang2-mod-pcre is not set
-# CONFIG_PACKAGE_libslang2-mod-png is not set
-# CONFIG_PACKAGE_libslang2-mod-rand is not set
-# CONFIG_PACKAGE_libslang2-mod-select is not set
-# CONFIG_PACKAGE_libslang2-mod-slsmg is not set
-# CONFIG_PACKAGE_libslang2-mod-socket is not set
-# CONFIG_PACKAGE_libslang2-mod-stats is not set
-# CONFIG_PACKAGE_libslang2-mod-sysconf is not set
-# CONFIG_PACKAGE_libslang2-mod-termios is not set
-# CONFIG_PACKAGE_libslang2-mod-varray is not set
-# CONFIG_PACKAGE_libslang2-mod-zlib is not set
-# CONFIG_PACKAGE_libslang2-modules is not set
 # CONFIG_PACKAGE_libsmartcols is not set
-# CONFIG_PACKAGE_libsndfile is not set
-# CONFIG_PACKAGE_libsoc is not set
 # CONFIG_PACKAGE_libsocks is not set
-# CONFIG_PACKAGE_libsodium is not set
-# CONFIG_PACKAGE_libsoup is not set
-# CONFIG_PACKAGE_libsoxr is not set
-# CONFIG_PACKAGE_libspeex is not set
-# CONFIG_PACKAGE_libspeexdsp is not set
 # CONFIG_PACKAGE_libss is not set
-# CONFIG_PACKAGE_libssh is not set
-# CONFIG_PACKAGE_libssh2 is not set
-# CONFIG_PACKAGE_libstoken is not set
-# CONFIG_PACKAGE_libstrophe is not set
-# CONFIG_PACKAGE_libtalloc is not set
-# CONFIG_PACKAGE_libtasn1 is not set
-# CONFIG_PACKAGE_libtheora is not set
-# CONFIG_PACKAGE_libtiff is not set
-# CONFIG_PACKAGE_libtiffxx is not set
-# CONFIG_PACKAGE_libtins is not set
-# CONFIG_PACKAGE_libtirpc is not set
 CONFIG_PACKAGE_libubox=y
 # CONFIG_PACKAGE_libubox-lua is not set
 CONFIG_PACKAGE_libubus=y
@@ -4129,609 +2571,72 @@ CONFIG_PACKAGE_libubus=y
 CONFIG_PACKAGE_libuci=y
 # CONFIG_PACKAGE_libuci-lua is not set
 CONFIG_PACKAGE_libuclient=y
-# CONFIG_PACKAGE_libudev-fbsd is not set
-# CONFIG_PACKAGE_libudns is not set
-# CONFIG_PACKAGE_libuecc is not set
-# CONFIG_PACKAGE_libugpio is not set
-# CONFIG_PACKAGE_libunistring is not set
 # CONFIG_PACKAGE_libunwind is not set
-# CONFIG_PACKAGE_libupnp is not set
-# CONFIG_PACKAGE_libupnpp is not set
-# CONFIG_PACKAGE_liburcu is not set
 # CONFIG_PACKAGE_libusb-1.0 is not set
 # CONFIG_PACKAGE_libusb-compat is not set
 # CONFIG_PACKAGE_libustream-mbedtls is not set
 # CONFIG_PACKAGE_libustream-openssl is not set
 # CONFIG_PACKAGE_libustream-wolfssl is not set
 # CONFIG_PACKAGE_libuuid is not set
-# CONFIG_PACKAGE_libuv is not set
-# CONFIG_PACKAGE_libuvc is not set
-# CONFIG_PACKAGE_libv4l is not set
-# CONFIG_PACKAGE_libvorbis is not set
-# CONFIG_PACKAGE_libvorbisidec is not set
-# CONFIG_PACKAGE_libvpx is not set
-# CONFIG_PACKAGE_libwangle is not set
-# CONFIG_PACKAGE_libwebcam is not set
-# CONFIG_PACKAGE_libwebsockets-full is not set
-# CONFIG_PACKAGE_libwebsockets-mbedtls is not set
-# CONFIG_PACKAGE_libwebsockets-openssl is not set
-# CONFIG_PACKAGE_libwrap is not set
-# CONFIG_PACKAGE_libxerces-c is not set
-# CONFIG_PACKAGE_libxerces-c-samples is not set
-# CONFIG_PACKAGE_libxml2 is not set
-# CONFIG_PACKAGE_libxslt is not set
-# CONFIG_PACKAGE_libyaml-cpp is not set
-# CONFIG_PACKAGE_libyang is not set
-# CONFIG_PACKAGE_libyarpl is not set
-# CONFIG_PACKAGE_libyubikey is not set
-# CONFIG_PACKAGE_libzdb is not set
-# CONFIG_PACKAGE_libzmq-curve is not set
-# CONFIG_PACKAGE_libzmq-nc is not set
 # CONFIG_PACKAGE_linux-atm is not set
-# CONFIG_PACKAGE_lmdb is not set
-# CONFIG_PACKAGE_log4cplus is not set
-# CONFIG_PACKAGE_loudmouth is not set
-# CONFIG_PACKAGE_lttng-ust is not set
-# CONFIG_PACKAGE_measurement-kit is not set
-# CONFIG_PACKAGE_msgpack-c is not set
-# CONFIG_PACKAGE_mtdev is not set
-# CONFIG_PACKAGE_musl-fts is not set
-# CONFIG_PACKAGE_mxml is not set
-# CONFIG_PACKAGE_nspr is not set
-# CONFIG_PACKAGE_oniguruma is not set
-# CONFIG_PACKAGE_opencv is not set
-# CONFIG_PACKAGE_p11-kit is not set
-# CONFIG_PACKAGE_pixman is not set
-# CONFIG_PACKAGE_poco is not set
-# CONFIG_PACKAGE_protobuf is not set
-# CONFIG_PACKAGE_protobuf-lite is not set
-# CONFIG_PACKAGE_pthsem is not set
-# CONFIG_PACKAGE_re2 is not set
-CONFIG_RE2_SHARED=y
-# CONFIG_RE2_STATIC is not set
-# CONFIG_PACKAGE_rpcd-mod-luci is not set
-# CONFIG_PACKAGE_rpcd-mod-rad2-enc is not set
-# CONFIG_PACKAGE_rpcd-mod-rrdns is not set
-# CONFIG_PACKAGE_rxtx is not set
-# CONFIG_PACKAGE_sbc is not set
 # CONFIG_PACKAGE_terminfo is not set
-# CONFIG_PACKAGE_tinycdb is not set
 # CONFIG_PACKAGE_uclibcxx is not set
-# CONFIG_PACKAGE_uw-imap is not set
-# CONFIG_PACKAGE_xmlrpc-c is not set
-# CONFIG_PACKAGE_xmlrpc-c-client is not set
-# CONFIG_PACKAGE_xmlrpc-c-server is not set
-# CONFIG_PACKAGE_yajl is not set
-# CONFIG_PACKAGE_yubico-pam is not set
-# CONFIG_PACKAGE_zlib is not set
+CONFIG_PACKAGE_zlib=y
 
 #
-# LuCI
+# Configuration
 #
-
-#
-# 1. Collections
-#
-# CONFIG_PACKAGE_luci is not set
-# CONFIG_PACKAGE_luci-nginx is not set
-# CONFIG_PACKAGE_luci-ssl is not set
-# CONFIG_PACKAGE_luci-ssl-nginx is not set
-# CONFIG_PACKAGE_luci-ssl-openssl is not set
-
-#
-# 2. Modules
-#
-# CONFIG_PACKAGE_luci-base is not set
-# CONFIG_LUCI_SRCDIET is not set
-CONFIG_LUCI_JSMIN=y
-CONFIG_LUCI_CSSTIDY=y
-
-#
-# Translations
-#
-# CONFIG_LUCI_LANG_bg is not set
-# CONFIG_LUCI_LANG_ca is not set
-# CONFIG_LUCI_LANG_cs is not set
-# CONFIG_LUCI_LANG_de is not set
-# CONFIG_LUCI_LANG_el is not set
-# CONFIG_LUCI_LANG_en is not set
-# CONFIG_LUCI_LANG_es is not set
-# CONFIG_LUCI_LANG_fr is not set
-# CONFIG_LUCI_LANG_he is not set
-# CONFIG_LUCI_LANG_hi is not set
-# CONFIG_LUCI_LANG_hu is not set
-# CONFIG_LUCI_LANG_it is not set
-# CONFIG_LUCI_LANG_ja is not set
-# CONFIG_LUCI_LANG_ko is not set
-# CONFIG_LUCI_LANG_mr is not set
-# CONFIG_LUCI_LANG_ms is not set
-# CONFIG_LUCI_LANG_nb_NO is not set
-# CONFIG_LUCI_LANG_pl is not set
-# CONFIG_LUCI_LANG_pt is not set
-# CONFIG_LUCI_LANG_pt_BR is not set
-# CONFIG_LUCI_LANG_ro is not set
-# CONFIG_LUCI_LANG_ru is not set
-# CONFIG_LUCI_LANG_sk is not set
-# CONFIG_LUCI_LANG_sv is not set
-# CONFIG_LUCI_LANG_tr is not set
-# CONFIG_LUCI_LANG_uk is not set
-# CONFIG_LUCI_LANG_vi is not set
-# CONFIG_LUCI_LANG_zh_Hans is not set
-# CONFIG_LUCI_LANG_zh_Hant is not set
-# CONFIG_PACKAGE_luci-compat is not set
-# CONFIG_PACKAGE_luci-mod-admin-full is not set
-# CONFIG_PACKAGE_luci-mod-failsafe is not set
-# CONFIG_PACKAGE_luci-mod-freifunk is not set
-# CONFIG_PACKAGE_luci-mod-freifunk-community is not set
-# CONFIG_PACKAGE_luci-mod-network is not set
-# CONFIG_PACKAGE_luci-mod-rpc is not set
-# CONFIG_PACKAGE_luci-mod-status is not set
-# CONFIG_PACKAGE_luci-mod-system is not set
-
-#
-# 3. Applications
-#
-# CONFIG_PACKAGE_luci-app-adblock is not set
-# CONFIG_PACKAGE_luci-app-advanced-reboot is not set
-# CONFIG_PACKAGE_luci-app-ahcp is not set
-# CONFIG_PACKAGE_luci-app-aria2 is not set
-# CONFIG_PACKAGE_luci-app-banip is not set
-# CONFIG_PACKAGE_luci-app-bcp38 is not set
-# CONFIG_PACKAGE_luci-app-bird1-ipv4 is not set
-# CONFIG_PACKAGE_luci-app-bird1-ipv6 is not set
-# CONFIG_PACKAGE_luci-app-bmx6 is not set
-# CONFIG_PACKAGE_luci-app-bmx7 is not set
-# CONFIG_PACKAGE_luci-app-cjdns is not set
-# CONFIG_PACKAGE_luci-app-clamav is not set
-# CONFIG_PACKAGE_luci-app-commands is not set
-# CONFIG_PACKAGE_luci-app-cshark is not set
-# CONFIG_PACKAGE_luci-app-dcwapd is not set
-# CONFIG_PACKAGE_luci-app-ddns is not set
-# CONFIG_PACKAGE_luci-app-diag-core is not set
-# CONFIG_PACKAGE_luci-app-dnscrypt-proxy is not set
-# CONFIG_PACKAGE_luci-app-dump1090 is not set
-# CONFIG_PACKAGE_luci-app-dynapoint is not set
-# CONFIG_PACKAGE_luci-app-e2guardian is not set
-# CONFIG_PACKAGE_luci-app-firewall is not set
-# CONFIG_PACKAGE_luci-app-freifunk-diagnostics is not set
-# CONFIG_PACKAGE_luci-app-freifunk-policyrouting is not set
-# CONFIG_PACKAGE_luci-app-fwknopd is not set
-# CONFIG_PACKAGE_luci-app-hd-idle is not set
-# CONFIG_PACKAGE_luci-app-hnet is not set
-# CONFIG_PACKAGE_luci-app-https-dns-proxy is not set
-# CONFIG_PACKAGE_luci-app-ksmbd is not set
-# CONFIG_PACKAGE_luci-app-lxc is not set
-# CONFIG_PACKAGE_luci-app-meshwizard is not set
-# CONFIG_PACKAGE_luci-app-minidlna is not set
-# CONFIG_PACKAGE_luci-app-mjpg-streamer is not set
-# CONFIG_PACKAGE_luci-app-mwan3 is not set
-# CONFIG_PACKAGE_luci-app-nextdns is not set
-# CONFIG_PACKAGE_luci-app-nft-qos is not set
-# CONFIG_PACKAGE_luci-app-nlbwmon is not set
-# CONFIG_PACKAGE_luci-app-ntpc is not set
-# CONFIG_PACKAGE_luci-app-nut is not set
-# CONFIG_PACKAGE_luci-app-ocserv is not set
-# CONFIG_PACKAGE_luci-app-olsr is not set
-# CONFIG_PACKAGE_luci-app-olsr-services is not set
-# CONFIG_PACKAGE_luci-app-olsr-viz is not set
-# CONFIG_PACKAGE_luci-app-openvpn is not set
-# CONFIG_PACKAGE_luci-app-opkg is not set
-# CONFIG_PACKAGE_luci-app-p910nd is not set
-# CONFIG_PACKAGE_luci-app-pagekitec is not set
-# CONFIG_PACKAGE_luci-app-polipo is not set
-# CONFIG_PACKAGE_luci-app-privoxy is not set
-# CONFIG_PACKAGE_luci-app-qos is not set
-# CONFIG_PACKAGE_luci-app-radicale is not set
-# CONFIG_PACKAGE_luci-app-radicale2 is not set
-# CONFIG_PACKAGE_luci-app-rosy-file-server is not set
-# CONFIG_PACKAGE_luci-app-rp-pppoe-server is not set
-# CONFIG_PACKAGE_luci-app-samba is not set
-# CONFIG_PACKAGE_luci-app-samba4 is not set
-# CONFIG_PACKAGE_luci-app-shadowsocks-libev is not set
-# CONFIG_PACKAGE_luci-app-shairplay is not set
-# CONFIG_PACKAGE_luci-app-siitwizard is not set
-# CONFIG_PACKAGE_luci-app-simple-adblock is not set
-# CONFIG_PACKAGE_luci-app-snmpd is not set
-# CONFIG_PACKAGE_luci-app-splash is not set
-# CONFIG_PACKAGE_luci-app-sqm is not set
-# CONFIG_PACKAGE_luci-app-squid is not set
-# CONFIG_PACKAGE_luci-app-statistics is not set
-# CONFIG_PACKAGE_luci-app-tinyproxy is not set
-# CONFIG_PACKAGE_luci-app-transmission is not set
-# CONFIG_PACKAGE_luci-app-travelmate is not set
-# CONFIG_PACKAGE_luci-app-ttyd is not set
-# CONFIG_PACKAGE_luci-app-udpxy is not set
-# CONFIG_PACKAGE_luci-app-uhttpd is not set
-# CONFIG_PACKAGE_luci-app-unbound is not set
-# CONFIG_PACKAGE_luci-app-upnp is not set
-# CONFIG_PACKAGE_luci-app-vnstat is not set
-# CONFIG_PACKAGE_luci-app-vpn-policy-routing is not set
-# CONFIG_PACKAGE_luci-app-vpnbypass is not set
-# CONFIG_PACKAGE_luci-app-watchcat is not set
-# CONFIG_PACKAGE_luci-app-wifischedule is not set
-# CONFIG_PACKAGE_luci-app-wireguard is not set
-# CONFIG_PACKAGE_luci-app-wol is not set
-
-#
-# 4. Themes
-#
-# CONFIG_PACKAGE_luci-theme-bootstrap is not set
-# CONFIG_PACKAGE_luci-theme-freifunk-generic is not set
-# CONFIG_PACKAGE_luci-theme-material is not set
-# CONFIG_PACKAGE_luci-theme-openwrt is not set
-
-#
-# 5. Protocols
-#
-# CONFIG_PACKAGE_luci-proto-3g is not set
-# CONFIG_PACKAGE_luci-proto-gre is not set
-# CONFIG_PACKAGE_luci-proto-hnet is not set
-# CONFIG_PACKAGE_luci-proto-ipip is not set
-# CONFIG_PACKAGE_luci-proto-ipv6 is not set
-# CONFIG_PACKAGE_luci-proto-openconnect is not set
-# CONFIG_PACKAGE_luci-proto-ppp is not set
-# CONFIG_PACKAGE_luci-proto-pppossh is not set
-# CONFIG_PACKAGE_luci-proto-qmi is not set
-# CONFIG_PACKAGE_luci-proto-relay is not set
-# CONFIG_PACKAGE_luci-proto-vpnc is not set
-# CONFIG_PACKAGE_luci-proto-wireguard is not set
-
-#
-# 6. Libraries
-#
-# CONFIG_PACKAGE_luci-lib-dracula is not set
-# CONFIG_PACKAGE_luci-lib-httpclient is not set
-# CONFIG_PACKAGE_luci-lib-httpprotoutils is not set
-# CONFIG_PACKAGE_luci-lib-ip is not set
-# CONFIG_PACKAGE_luci-lib-ipkg is not set
-# CONFIG_PACKAGE_luci-lib-iptparser is not set
-# CONFIG_PACKAGE_luci-lib-jquery-1-4 is not set
-# CONFIG_PACKAGE_luci-lib-json is not set
-# CONFIG_PACKAGE_luci-lib-jsonc is not set
-# CONFIG_PACKAGE_luci-lib-nixio is not set
-CONFIG_PACKAGE_luci-lib-nixio_notls=y
-# CONFIG_PACKAGE_luci-lib-nixio_axtls is not set
-# CONFIG_PACKAGE_luci-lib-nixio_cyassl is not set
-# CONFIG_PACKAGE_luci-lib-nixio_openssl is not set
-# CONFIG_PACKAGE_luci-lib-px5g is not set
-
-#
-# 9. Freifunk
-#
-# CONFIG_PACKAGE_freifunk-common is not set
-# CONFIG_PACKAGE_freifunk-firewall is not set
-# CONFIG_PACKAGE_freifunk-policyrouting is not set
-# CONFIG_PACKAGE_freifunk-watchdog is not set
-# CONFIG_PACKAGE_meshwizard is not set
-
-#
-# Mail
-#
-# CONFIG_PACKAGE_alpine is not set
-# CONFIG_PACKAGE_alpine-nossl is not set
-# CONFIG_PACKAGE_bogofilter is not set
-# CONFIG_PACKAGE_clamsmtp is not set
-# CONFIG_PACKAGE_dovecot is not set
-# CONFIG_PACKAGE_dovecot-pigeonhole is not set
-# CONFIG_PACKAGE_dovecot-utils is not set
-# CONFIG_PACKAGE_emailrelay is not set
-# CONFIG_PACKAGE_fdm is not set
-# CONFIG_PACKAGE_greyfix is not set
-# CONFIG_PACKAGE_mailman is not set
-# CONFIG_PACKAGE_mailsend is not set
-# CONFIG_PACKAGE_mailsend-nossl is not set
-# CONFIG_PACKAGE_msmtp is not set
-# CONFIG_PACKAGE_msmtp-mta is not set
-# CONFIG_PACKAGE_msmtp-nossl is not set
-# CONFIG_PACKAGE_msmtp-queue is not set
-# CONFIG_PACKAGE_mutt is not set
-# CONFIG_PACKAGE_nail is not set
-# CONFIG_PACKAGE_opendkim is not set
-# CONFIG_PACKAGE_opendkim-tools is not set
-# CONFIG_PACKAGE_postfix is not set
-
-#
-# Select postfix build options
-#
-CONFIG_POSTFIX_TLS=y
-CONFIG_POSTFIX_SASL=y
-CONFIG_POSTFIX_LDAP=y
-# CONFIG_POSTFIX_DB is not set
-CONFIG_POSTFIX_CDB=y
-CONFIG_POSTFIX_SQLITE=y
-# CONFIG_POSTFIX_MYSQL is not set
-# CONFIG_POSTFIX_PGSQL is not set
-CONFIG_POSTFIX_PCRE=y
-# CONFIG_POSTFIX_EAI is not set
-# CONFIG_PACKAGE_ssmtp is not set
+# CONFIG_ZLIB_OPTIMIZE_SPEED is not set
 
 #
 # Multimedia
 #
-
-#
-# Streaming
-#
-# CONFIG_PACKAGE_oggfwd is not set
-# CONFIG_PACKAGE_crtmpserver is not set
 # CONFIG_PACKAGE_ffmpeg is not set
 # CONFIG_PACKAGE_ffprobe is not set
 # CONFIG_PACKAGE_ffserver is not set
-# CONFIG_PACKAGE_fswebcam is not set
-# CONFIG_PACKAGE_gerbera is not set
-# CONFIG_PACKAGE_gphoto2 is not set
-# CONFIG_PACKAGE_graphicsmagick is not set
-# CONFIG_PACKAGE_grilo is not set
-# CONFIG_PACKAGE_grilo-plugins is not set
-# CONFIG_PACKAGE_gst1-libav is not set
-# CONFIG_PACKAGE_gstreamer1-libs is not set
-# CONFIG_PACKAGE_gstreamer1-plugins-bad is not set
-# CONFIG_PACKAGE_gstreamer1-plugins-base is not set
-# CONFIG_PACKAGE_gstreamer1-plugins-good is not set
-# CONFIG_PACKAGE_gstreamer1-plugins-ugly is not set
-# CONFIG_PACKAGE_gstreamer1-utils is not set
-# CONFIG_PACKAGE_icecast is not set
-# CONFIG_PACKAGE_lcdgrilo is not set
-# CONFIG_PACKAGE_minidlna is not set
-# CONFIG_PACKAGE_mjpg-streamer is not set
-# CONFIG_PACKAGE_motion is not set
-# CONFIG_PACKAGE_tvheadend is not set
-# CONFIG_PACKAGE_v4l2rtspserver is not set
-# CONFIG_PACKAGE_vips is not set
-# CONFIG_PACKAGE_xupnpd is not set
-# CONFIG_PACKAGE_youtube-dl is not set
-# CONFIG_PACKAGE_youtube-dl-src is not set
 
 #
 # Network
 #
 
 #
-# BitTorrent
-#
-# CONFIG_PACKAGE_mktorrent is not set
-# CONFIG_PACKAGE_opentracker is not set
-# CONFIG_PACKAGE_opentracker6 is not set
-# CONFIG_PACKAGE_rtorrent is not set
-# CONFIG_PACKAGE_rtorrent-rpc is not set
-# CONFIG_PACKAGE_transmission-cli-mbedtls is not set
-# CONFIG_PACKAGE_transmission-cli-openssl is not set
-# CONFIG_PACKAGE_transmission-daemon-mbedtls is not set
-# CONFIG_PACKAGE_transmission-daemon-openssl is not set
-# CONFIG_PACKAGE_transmission-remote-mbedtls is not set
-# CONFIG_PACKAGE_transmission-remote-openssl is not set
-
-#
-# Captive Portals
-#
-# CONFIG_PACKAGE_apfree-wifidog is not set
-# CONFIG_PACKAGE_coova-chilli is not set
-# CONFIG_PACKAGE_nodogsplash is not set
-# CONFIG_PACKAGE_opennds is not set
-# CONFIG_PACKAGE_wifidog is not set
-# CONFIG_PACKAGE_wifidog-ng-mbedtls is not set
-# CONFIG_PACKAGE_wifidog-ng-nossl is not set
-# CONFIG_PACKAGE_wifidog-ng-openssl is not set
-# CONFIG_PACKAGE_wifidog-ng-wolfssl is not set
-# CONFIG_PACKAGE_wifidog-tls is not set
-
-#
-# Download Manager
-#
-# CONFIG_PACKAGE_ariang is not set
-# CONFIG_PACKAGE_ariang-nginx is not set
-# CONFIG_PACKAGE_webui-aria2 is not set
-
-#
 # File Transfer
 #
-# CONFIG_PACKAGE_aria2 is not set
-# CONFIG_PACKAGE_atftp is not set
-# CONFIG_PACKAGE_atftpd is not set
 # CONFIG_PACKAGE_curl is not set
-# CONFIG_PACKAGE_gnurl is not set
-# CONFIG_PACKAGE_lftp is not set
-# CONFIG_PACKAGE_rosy-file-server is not set
-# CONFIG_PACKAGE_rsync is not set
-# CONFIG_PACKAGE_rsyncd is not set
-# CONFIG_PACKAGE_vsftpd is not set
-# CONFIG_PACKAGE_vsftpd-tls is not set
-# CONFIG_PACKAGE_wget is not set
-# CONFIG_PACKAGE_wget-nossl is not set
-
-#
-# Filesystem
-#
-# CONFIG_PACKAGE_davfs2 is not set
-# CONFIG_PACKAGE_ksmbd-avahi-service is not set
-# CONFIG_PACKAGE_ksmbd-server is not set
-# CONFIG_PACKAGE_ksmbd-utils is not set
-# CONFIG_PACKAGE_netatalk is not set
-# CONFIG_PACKAGE_nfs-kernel-server is not set
-# CONFIG_PACKAGE_owftpd is not set
-# CONFIG_PACKAGE_owhttpd is not set
-# CONFIG_PACKAGE_owserver is not set
-# CONFIG_PACKAGE_sshfs is not set
 
 #
 # Firewall
 #
 # CONFIG_PACKAGE_arptables is not set
-# CONFIG_PACKAGE_conntrack is not set
-# CONFIG_PACKAGE_conntrackd is not set
 # CONFIG_PACKAGE_ebtables is not set
-# CONFIG_PACKAGE_fwknop is not set
-# CONFIG_PACKAGE_fwknopd is not set
 CONFIG_PACKAGE_ip6tables=y
 # CONFIG_PACKAGE_ip6tables-extra is not set
 # CONFIG_PACKAGE_ip6tables-mod-nat is not set
 CONFIG_PACKAGE_iptables=y
 # CONFIG_IPTABLES_CONNLABEL is not set
 # CONFIG_IPTABLES_NFTABLES is not set
-# CONFIG_PACKAGE_iptables-mod-account is not set
-# CONFIG_PACKAGE_iptables-mod-chaos is not set
 # CONFIG_PACKAGE_iptables-mod-checksum is not set
 # CONFIG_PACKAGE_iptables-mod-cluster is not set
 # CONFIG_PACKAGE_iptables-mod-clusterip is not set
-# CONFIG_PACKAGE_iptables-mod-condition is not set
 # CONFIG_PACKAGE_iptables-mod-conntrack-extra is not set
-# CONFIG_PACKAGE_iptables-mod-delude is not set
-# CONFIG_PACKAGE_iptables-mod-dhcpmac is not set
-# CONFIG_PACKAGE_iptables-mod-dnetmap is not set
 # CONFIG_PACKAGE_iptables-mod-extra is not set
 # CONFIG_PACKAGE_iptables-mod-filter is not set
-# CONFIG_PACKAGE_iptables-mod-fuzzy is not set
-# CONFIG_PACKAGE_iptables-mod-geoip is not set
 # CONFIG_PACKAGE_iptables-mod-hashlimit is not set
-# CONFIG_PACKAGE_iptables-mod-iface is not set
-# CONFIG_PACKAGE_iptables-mod-ipmark is not set
 # CONFIG_PACKAGE_iptables-mod-ipopt is not set
-# CONFIG_PACKAGE_iptables-mod-ipp2p is not set
 # CONFIG_PACKAGE_iptables-mod-iprange is not set
 # CONFIG_PACKAGE_iptables-mod-ipsec is not set
-# CONFIG_PACKAGE_iptables-mod-ipv4options is not set
 # CONFIG_PACKAGE_iptables-mod-led is not set
-# CONFIG_PACKAGE_iptables-mod-length2 is not set
-# CONFIG_PACKAGE_iptables-mod-logmark is not set
-# CONFIG_PACKAGE_iptables-mod-lscan is not set
-# CONFIG_PACKAGE_iptables-mod-lua is not set
 # CONFIG_PACKAGE_iptables-mod-nat-extra is not set
 # CONFIG_PACKAGE_iptables-mod-nflog is not set
 # CONFIG_PACKAGE_iptables-mod-nfqueue is not set
 # CONFIG_PACKAGE_iptables-mod-physdev is not set
-# CONFIG_PACKAGE_iptables-mod-psd is not set
-# CONFIG_PACKAGE_iptables-mod-quota2 is not set
 # CONFIG_PACKAGE_iptables-mod-rpfilter is not set
-# CONFIG_PACKAGE_iptables-mod-sysrq is not set
-# CONFIG_PACKAGE_iptables-mod-tarpit is not set
 # CONFIG_PACKAGE_iptables-mod-tee is not set
 # CONFIG_PACKAGE_iptables-mod-tproxy is not set
 # CONFIG_PACKAGE_iptables-mod-trace is not set
 # CONFIG_PACKAGE_iptables-mod-u32 is not set
 # CONFIG_PACKAGE_iptables-mod-ulog is not set
-# CONFIG_PACKAGE_iptaccount is not set
-# CONFIG_PACKAGE_iptgeoip is not set
-# CONFIG_PACKAGE_miniupnpc is not set
-# CONFIG_PACKAGE_miniupnpd is not set
-# CONFIG_PACKAGE_natpmpc is not set
 # CONFIG_PACKAGE_nftables is not set
-# CONFIG_PACKAGE_shorewall is not set
-# CONFIG_PACKAGE_shorewall-core is not set
-# CONFIG_PACKAGE_shorewall-lite is not set
-# CONFIG_PACKAGE_shorewall6 is not set
-# CONFIG_PACKAGE_shorewall6-lite is not set
-# CONFIG_PACKAGE_snort is not set
-# CONFIG_PACKAGE_snort3 is not set
-
-#
-# Firewall Tunnel
-#
-# CONFIG_PACKAGE_iodine is not set
-# CONFIG_PACKAGE_iodined is not set
-
-#
-# FreeRADIUS (version 3)
-#
-# CONFIG_PACKAGE_freeradius3 is not set
-# CONFIG_PACKAGE_freeradius3-common is not set
-# CONFIG_PACKAGE_freeradius3-utils is not set
-
-#
-# IP Addresses and Names
-#
-# CONFIG_PACKAGE_aggregate is not set
-# CONFIG_PACKAGE_announce is not set
-# CONFIG_PACKAGE_avahi-autoipd is not set
-# CONFIG_PACKAGE_avahi-daemon-service-http is not set
-# CONFIG_PACKAGE_avahi-daemon-service-ssh is not set
-# CONFIG_PACKAGE_avahi-dbus-daemon is not set
-# CONFIG_PACKAGE_avahi-dnsconfd is not set
-# CONFIG_PACKAGE_avahi-nodbus-daemon is not set
-# CONFIG_PACKAGE_avahi-utils is not set
-# CONFIG_PACKAGE_bind-check is not set
-# CONFIG_PACKAGE_bind-client is not set
-# CONFIG_PACKAGE_bind-dig is not set
-# CONFIG_PACKAGE_bind-dnssec is not set
-# CONFIG_PACKAGE_bind-host is not set
-# CONFIG_PACKAGE_bind-nslookup is not set
-# CONFIG_PACKAGE_bind-rndc is not set
-# CONFIG_PACKAGE_bind-server is not set
-# CONFIG_PACKAGE_bind-tools is not set
-# CONFIG_PACKAGE_danish is not set
-# CONFIG_PACKAGE_ddns-scripts is not set
-# CONFIG_PACKAGE_dhcp-forwarder is not set
-# CONFIG_PACKAGE_dnscrypt-proxy is not set
-# CONFIG_PACKAGE_dnscrypt-proxy-resolvers is not set
-# CONFIG_PACKAGE_dnsdist is not set
-
-#
-# SSL support
-#
-CONFIG_DNSDIST_OPENSSL=y
-# CONFIG_DNSDIST_GNUTLS is not set
-# CONFIG_DNSDIST_NOSSL is not set
-# CONFIG_PACKAGE_drill is not set
-# CONFIG_PACKAGE_hostip is not set
-# CONFIG_PACKAGE_idn is not set
-# CONFIG_PACKAGE_idn2 is not set
-# CONFIG_PACKAGE_inadyn is not set
-# CONFIG_PACKAGE_isc-dhcp-client-ipv4 is not set
-# CONFIG_PACKAGE_isc-dhcp-client-ipv6 is not set
-# CONFIG_PACKAGE_isc-dhcp-omshell-ipv4 is not set
-# CONFIG_PACKAGE_isc-dhcp-omshell-ipv6 is not set
-# CONFIG_PACKAGE_isc-dhcp-relay-ipv4 is not set
-# CONFIG_PACKAGE_isc-dhcp-relay-ipv6 is not set
-# CONFIG_PACKAGE_isc-dhcp-server-ipv4 is not set
-# CONFIG_PACKAGE_isc-dhcp-server-ipv6 is not set
-# CONFIG_PACKAGE_kadnode is not set
-# CONFIG_PACKAGE_kea-admin is not set
-# CONFIG_PACKAGE_kea-ctrl is not set
-# CONFIG_PACKAGE_kea-dhcp-ddns is not set
-# CONFIG_PACKAGE_kea-dhcp4 is not set
-# CONFIG_PACKAGE_kea-dhcp6 is not set
-# CONFIG_PACKAGE_kea-lfc is not set
-# CONFIG_PACKAGE_kea-libs is not set
-# CONFIG_PACKAGE_kea-perfdhcp is not set
-# CONFIG_PACKAGE_knot is not set
-# CONFIG_PACKAGE_knot-dig is not set
-# CONFIG_PACKAGE_knot-host is not set
-# CONFIG_PACKAGE_knot-keymgr is not set
-# CONFIG_PACKAGE_knot-nsupdate is not set
-# CONFIG_PACKAGE_knot-tests is not set
-# CONFIG_PACKAGE_knot-zonecheck is not set
-# CONFIG_PACKAGE_mdns-utils is not set
-# CONFIG_PACKAGE_mdnsd is not set
-# CONFIG_PACKAGE_mdnsresponder is not set
-# CONFIG_PACKAGE_nsd is not set
-# CONFIG_PACKAGE_nsd-control is not set
-# CONFIG_PACKAGE_nsd-control-setup is not set
-# CONFIG_PACKAGE_nsd-nossl is not set
-# CONFIG_PACKAGE_ohybridproxy is not set
-# CONFIG_PACKAGE_stubby is not set
-# CONFIG_PACKAGE_tor-hs is not set
-# CONFIG_PACKAGE_torsocks is not set
-# CONFIG_PACKAGE_unbound-anchor is not set
-# CONFIG_PACKAGE_unbound-checkconf is not set
-# CONFIG_PACKAGE_unbound-control is not set
-# CONFIG_PACKAGE_unbound-control-setup is not set
-# CONFIG_PACKAGE_unbound-daemon is not set
-# CONFIG_PACKAGE_unbound-daemon-heavy is not set
-# CONFIG_PACKAGE_unbound-host is not set
-# CONFIG_PACKAGE_wsdd2 is not set
-# CONFIG_PACKAGE_zonestitcher is not set
-
-#
-# Instant Messaging
-#
-# CONFIG_PACKAGE_bitlbee is not set
-# CONFIG_PACKAGE_irssi is not set
-# CONFIG_PACKAGE_ngircd is not set
-# CONFIG_PACKAGE_ngircd-nossl is not set
-# CONFIG_PACKAGE_prosody is not set
-# CONFIG_PACKAGE_quassel-irssi is not set
-# CONFIG_PACKAGE_umurmur-mbedtls is not set
-# CONFIG_PACKAGE_umurmur-openssl is not set
-# CONFIG_PACKAGE_znc is not set
 
 #
 # Linux ATM tools
@@ -4764,86 +2669,8 @@ CONFIG_DNSDIST_OPENSSL=y
 # CONFIG_PACKAGE_br2684ctl is not set
 
 #
-# LoRaWAN
-#
-# CONFIG_PACKAGE_libloragw-tests is not set
-# CONFIG_PACKAGE_libloragw-utils is not set
-
-#
-# NMAP Suite
-#
-# CONFIG_PACKAGE_ncat is not set
-# CONFIG_PACKAGE_ncat-ssl is not set
-# CONFIG_PACKAGE_ndiff is not set
-# CONFIG_PACKAGE_nmap is not set
-# CONFIG_PACKAGE_nmap-ssl is not set
-# CONFIG_PACKAGE_nping is not set
-
-#
-# NTRIP
-#
-# CONFIG_PACKAGE_ntripcaster is not set
-# CONFIG_PACKAGE_ntripclient is not set
-# CONFIG_PACKAGE_ntripserver is not set
-
-#
-# OLSR.org network framework
-#
-# CONFIG_PACKAGE_oonf-dlep-proxy is not set
-# CONFIG_PACKAGE_oonf-dlep-radio is not set
-# CONFIG_PACKAGE_oonf-init-scripts is not set
-# CONFIG_PACKAGE_oonf-olsrd2 is not set
-
-#
-# Open vSwitch
-#
-# CONFIG_PACKAGE_openvswitch is not set
-# CONFIG_PACKAGE_openvswitch-ovn-host is not set
-# CONFIG_PACKAGE_openvswitch-ovn-north is not set
-# CONFIG_PACKAGE_openvswitch-python is not set
-# CONFIG_PACKAGE_openvswitch-python3 is not set
-
-#
-# OpenLDAP
-#
-# CONFIG_PACKAGE_libopenldap is not set
-CONFIG_OPENLDAP_DEBUG=y
-# CONFIG_OPENLDAP_CRYPT is not set
-# CONFIG_OPENLDAP_MONITOR is not set
-# CONFIG_OPENLDAP_DB47 is not set
-# CONFIG_OPENLDAP_ICU is not set
-# CONFIG_PACKAGE_openldap-server is not set
-# CONFIG_PACKAGE_openldap-utils is not set
-
-#
-# Printing
-#
-# CONFIG_PACKAGE_p910nd is not set
-
-#
 # Routing and Redirection
 #
-# CONFIG_PACKAGE_babel-pinger is not set
-# CONFIG_PACKAGE_babeld is not set
-# CONFIG_PACKAGE_batmand is not set
-# CONFIG_PACKAGE_bcp38 is not set
-# CONFIG_PACKAGE_bird1-ipv4 is not set
-# CONFIG_PACKAGE_bird1-ipv4-uci is not set
-# CONFIG_PACKAGE_bird1-ipv6 is not set
-# CONFIG_PACKAGE_bird1-ipv6-uci is not set
-# CONFIG_PACKAGE_bird1c-ipv4 is not set
-# CONFIG_PACKAGE_bird1c-ipv6 is not set
-# CONFIG_PACKAGE_bird1cl-ipv4 is not set
-# CONFIG_PACKAGE_bird1cl-ipv6 is not set
-# CONFIG_PACKAGE_bird2 is not set
-# CONFIG_PACKAGE_bird2c is not set
-# CONFIG_PACKAGE_bird2cl is not set
-# CONFIG_PACKAGE_bmx6 is not set
-# CONFIG_PACKAGE_bmx7 is not set
-# CONFIG_PACKAGE_cjdns is not set
-# CONFIG_PACKAGE_cjdns-tests is not set
-# CONFIG_PACKAGE_dcstad is not set
-# CONFIG_PACKAGE_dcwapd is not set
 # CONFIG_PACKAGE_devlink is not set
 # CONFIG_PACKAGE_genl is not set
 # CONFIG_PACKAGE_igmpproxy is not set
@@ -4851,38 +2678,11 @@ CONFIG_OPENLDAP_DEBUG=y
 # CONFIG_PACKAGE_ip-full is not set
 # CONFIG_PACKAGE_ip-tiny is not set
 # CONFIG_PACKAGE_lldpd is not set
-# CONFIG_PACKAGE_mcproxy is not set
-# CONFIG_PACKAGE_mrmctl is not set
-# CONFIG_PACKAGE_mwan3 is not set
 # CONFIG_PACKAGE_nstat is not set
-# CONFIG_PACKAGE_olsrd is not set
-# CONFIG_PACKAGE_prince is not set
-# CONFIG_PACKAGE_quagga is not set
 # CONFIG_PACKAGE_rdma is not set
 # CONFIG_PACKAGE_relayd is not set
-# CONFIG_PACKAGE_smcroute is not set
 # CONFIG_PACKAGE_ss is not set
-# CONFIG_PACKAGE_sslh is not set
 # CONFIG_PACKAGE_tc is not set
-# CONFIG_PACKAGE_tcpproxy is not set
-# CONFIG_PACKAGE_vis is not set
-# CONFIG_PACKAGE_yggdrasil is not set
-
-#
-# SSH
-#
-# CONFIG_PACKAGE_autossh is not set
-# CONFIG_PACKAGE_openssh-client is not set
-# CONFIG_PACKAGE_openssh-client-utils is not set
-# CONFIG_PACKAGE_openssh-keygen is not set
-# CONFIG_PACKAGE_openssh-moduli is not set
-# CONFIG_PACKAGE_openssh-server is not set
-# CONFIG_PACKAGE_openssh-server-pam is not set
-# CONFIG_PACKAGE_openssh-sftp-avahi-service is not set
-# CONFIG_PACKAGE_openssh-sftp-client is not set
-# CONFIG_PACKAGE_openssh-sftp-server is not set
-# CONFIG_PACKAGE_sshtunnel is not set
-# CONFIG_PACKAGE_tmate is not set
 
 #
 # THC-IPv6 attack and analyzing toolkit
@@ -4941,80 +2741,14 @@ CONFIG_OPENLDAP_DEBUG=y
 # CONFIG_PACKAGE_thc-ipv6-trace6 is not set
 
 #
-# Telephony
-#
-# CONFIG_PACKAGE_asterisk16 is not set
-# CONFIG_PACKAGE_baresip is not set
-# CONFIG_PACKAGE_freeswitch-stable is not set
-# CONFIG_PACKAGE_kamailio5 is not set
-# CONFIG_PACKAGE_miax is not set
-# CONFIG_PACKAGE_pcapsipdump is not set
-# CONFIG_PACKAGE_restund is not set
-# CONFIG_PACKAGE_rtpproxy is not set
-# CONFIG_PACKAGE_sipp is not set
-# CONFIG_PACKAGE_siproxd is not set
-# CONFIG_PACKAGE_yate is not set
-
-#
-# Telephony Lantiq
-#
-
-#
-# Time Synchronization
-#
-# CONFIG_PACKAGE_chrony is not set
-# CONFIG_PACKAGE_htpdate is not set
-# CONFIG_PACKAGE_linuxptp is not set
-# CONFIG_PACKAGE_ntp-keygen is not set
-# CONFIG_PACKAGE_ntp-utils is not set
-# CONFIG_PACKAGE_ntpclient is not set
-# CONFIG_PACKAGE_ntpd is not set
-# CONFIG_PACKAGE_ntpdate is not set
-
-#
 # VPN
 #
-# CONFIG_PACKAGE_chaosvpn is not set
-# CONFIG_PACKAGE_fastd is not set
-# CONFIG_PACKAGE_ipsec-tools is not set
-# CONFIG_PACKAGE_libreswan is not set
-# CONFIG_PACKAGE_ocserv is not set
-# CONFIG_PACKAGE_openconnect is not set
-# CONFIG_PACKAGE_opennhrp is not set
 # CONFIG_PACKAGE_openvpn-easy-rsa is not set
 # CONFIG_PACKAGE_openvpn-mbedtls is not set
 # CONFIG_PACKAGE_openvpn-nossl is not set
 # CONFIG_PACKAGE_openvpn-openssl is not set
-# CONFIG_PACKAGE_pptpd is not set
-# CONFIG_PACKAGE_softethervpn-base is not set
-# CONFIG_PACKAGE_softethervpn-bridge is not set
-# CONFIG_PACKAGE_softethervpn-client is not set
-# CONFIG_PACKAGE_softethervpn-server is not set
-# CONFIG_PACKAGE_softethervpn5-bridge is not set
-# CONFIG_PACKAGE_softethervpn5-client is not set
-# CONFIG_PACKAGE_softethervpn5-server is not set
-# CONFIG_PACKAGE_sstp-client is not set
-# CONFIG_PACKAGE_strongswan is not set
-# CONFIG_PACKAGE_tinc is not set
-# CONFIG_PACKAGE_uanytun is not set
-# CONFIG_PACKAGE_uanytun-nettle is not set
-# CONFIG_PACKAGE_uanytun-nocrypt is not set
-# CONFIG_PACKAGE_uanytun-sslcrypt is not set
-# CONFIG_PACKAGE_vpnc is not set
-# CONFIG_PACKAGE_vpnc-scripts is not set
 # CONFIG_PACKAGE_wireguard is not set
 # CONFIG_PACKAGE_wireguard-tools is not set
-# CONFIG_PACKAGE_xl2tpd is not set
-# CONFIG_PACKAGE_zerotier is not set
-
-#
-# Version Control Systems
-#
-# CONFIG_PACKAGE_git is not set
-# CONFIG_PACKAGE_git-http is not set
-# CONFIG_PACKAGE_subversion-client is not set
-# CONFIG_PACKAGE_subversion-libs is not set
-# CONFIG_PACKAGE_subversion-server is not set
 
 #
 # WWAN
@@ -5027,131 +2761,20 @@ CONFIG_OPENLDAP_DEBUG=y
 #
 # Web Servers/Proxies
 #
-# CONFIG_PACKAGE_apache is not set
-# CONFIG_PACKAGE_cgi-io is not set
-# CONFIG_PACKAGE_clamav is not set
-# CONFIG_PACKAGE_e2guardian is not set
-# CONFIG_PACKAGE_freshclam is not set
-# CONFIG_PACKAGE_haproxy is not set
-# CONFIG_PACKAGE_haproxy-nossl is not set
-# CONFIG_PACKAGE_kcptun-c is not set
-# CONFIG_PACKAGE_kcptun-s is not set
-# CONFIG_PACKAGE_lighttpd is not set
-# CONFIG_PACKAGE_nginx is not set
-# CONFIG_PACKAGE_nginx-all-module is not set
-# CONFIG_PACKAGE_nginx-mod-luci is not set
-# CONFIG_PACKAGE_nginx-mod-luci-ssl is not set
-# CONFIG_PACKAGE_nginx-ssl is not set
-# CONFIG_PACKAGE_polipo is not set
-# CONFIG_PACKAGE_privoxy is not set
-# CONFIG_PACKAGE_radicale-py2 is not set
-# CONFIG_PACKAGE_radicale-py3 is not set
-# CONFIG_PACKAGE_radicale2 is not set
-# CONFIG_PACKAGE_radicale2-examples is not set
-# CONFIG_PACKAGE_radicale2-src is not set
-# CONFIG_PACKAGE_shadowsocks-libev-config is not set
-# CONFIG_PACKAGE_shadowsocks-libev-ss-local is not set
-# CONFIG_PACKAGE_shadowsocks-libev-ss-redir is not set
-# CONFIG_PACKAGE_shadowsocks-libev-ss-rules is not set
-# CONFIG_PACKAGE_shadowsocks-libev-ss-server is not set
-# CONFIG_PACKAGE_shadowsocks-libev-ss-tunnel is not set
 # CONFIG_PACKAGE_sockd is not set
 # CONFIG_PACKAGE_socksify is not set
-# CONFIG_PACKAGE_spawn-fcgi is not set
-# CONFIG_PACKAGE_squid is not set
-# CONFIG_PACKAGE_tinyproxy is not set
 # CONFIG_PACKAGE_uhttpd is not set
-# CONFIG_PACKAGE_uwsgi is not set
-
-#
-# Wireless
-#
-# CONFIG_PACKAGE_hcxdumptool is not set
-# CONFIG_PACKAGE_hcxtools is not set
-
-#
-# dial-in/up
-#
-# CONFIG_PACKAGE_rp-pppoe-common is not set
-# CONFIG_PACKAGE_rp-pppoe-relay is not set
-# CONFIG_PACKAGE_rp-pppoe-server is not set
-
-#
-# tcprelay
-#
-# CONFIG_PACKAGE_tcpbridge is not set
-# CONFIG_PACKAGE_tcpcapinfo is not set
-# CONFIG_PACKAGE_tcpliveplay is not set
-# CONFIG_PACKAGE_tcpprep is not set
-# CONFIG_PACKAGE_tcpreplay is not set
-# CONFIG_PACKAGE_tcpreplay-all is not set
-# CONFIG_PACKAGE_tcpreplay-edit is not set
-# CONFIG_PACKAGE_tcprewrite is not set
-
-#
-# wireless
-#
-# CONFIG_PACKAGE_aircrack-ng is not set
-# CONFIG_PACKAGE_airmon-ng is not set
-# CONFIG_PACKAGE_dynapoint is not set
-# CONFIG_PACKAGE_horst is not set
-# CONFIG_PACKAGE_kismet-client is not set
-# CONFIG_PACKAGE_kismet-drone is not set
-# CONFIG_PACKAGE_kismet-server is not set
-# CONFIG_PACKAGE_pixiewps is not set
-# CONFIG_PACKAGE_reaver is not set
-# CONFIG_PACKAGE_wavemon is not set
-# CONFIG_PACKAGE_wifischedule is not set
 # CONFIG_PACKAGE_464xlat is not set
 # CONFIG_PACKAGE_6in4 is not set
 # CONFIG_PACKAGE_6rd is not set
 # CONFIG_PACKAGE_6to4 is not set
-# CONFIG_PACKAGE_acme is not set
-# CONFIG_PACKAGE_acme-dnsapi is not set
-# CONFIG_PACKAGE_adblock is not set
-# CONFIG_PACKAGE_addrwatch is not set
-# CONFIG_PACKAGE_ahcpd is not set
-# CONFIG_PACKAGE_alfred is not set
-# CONFIG_PACKAGE_apcupsd is not set
-# CONFIG_PACKAGE_apcupsd-cgi is not set
-# CONFIG_PACKAGE_apinger is not set
-# CONFIG_PACKAGE_arp-scan is not set
-# CONFIG_PACKAGE_banip is not set
-# CONFIG_PACKAGE_batctl-default is not set
-# CONFIG_PACKAGE_batctl-full is not set
-# CONFIG_PACKAGE_batctl-tiny is not set
-# CONFIG_PACKAGE_beanstalkd is not set
-# CONFIG_PACKAGE_bmon is not set
-# CONFIG_PACKAGE_boinc is not set
-# CONFIG_PACKAGE_bwm-ng is not set
 # CONFIG_PACKAGE_chat is not set
-# CONFIG_PACKAGE_cifsmount is not set
-# CONFIG_PACKAGE_coap-server is not set
-# CONFIG_PACKAGE_conserver is not set
-# CONFIG_PACKAGE_cshark is not set
-# CONFIG_PACKAGE_daemonlogger is not set
-# CONFIG_PACKAGE_darkstat is not set
-# CONFIG_PACKAGE_dhcpcd is not set
-# CONFIG_PACKAGE_dmapd is not set
-# CONFIG_PACKAGE_dnscrypt-proxy2 is not set
 # CONFIG_PACKAGE_ds-lite is not set
 # CONFIG_PACKAGE_eapol-test is not set
 # CONFIG_PACKAGE_eapol-test-openssl is not set
 # CONFIG_PACKAGE_eapol-test-wolfssl is not set
-# CONFIG_PACKAGE_esniper is not set
-# CONFIG_PACKAGE_etherwake is not set
 # CONFIG_PACKAGE_ethtool is not set
-# CONFIG_PACKAGE_fakeidentd is not set
-# CONFIG_PACKAGE_foolsm is not set
-# CONFIG_PACKAGE_fping is not set
-# CONFIG_PACKAGE_geth is not set
-# CONFIG_PACKAGE_gnunet is not set
 # CONFIG_PACKAGE_gre is not set
-# CONFIG_PACKAGE_hnet-full is not set
-# CONFIG_PACKAGE_hnet-full-l2tp is not set
-# CONFIG_PACKAGE_hnet-full-secure is not set
-# CONFIG_PACKAGE_hnetd-nossl is not set
-# CONFIG_PACKAGE_hnetd-openssl is not set
 # CONFIG_PACKAGE_hostapd is not set
 # CONFIG_PACKAGE_hostapd-basic is not set
 CONFIG_PACKAGE_hostapd-common=y
@@ -5159,31 +2782,13 @@ CONFIG_PACKAGE_hostapd-common=y
 # CONFIG_PACKAGE_hostapd-openssl is not set
 # CONFIG_PACKAGE_hostapd-utils is not set
 # CONFIG_PACKAGE_hostapd-wolfssl is not set
-# CONFIG_PACKAGE_httping is not set
-# CONFIG_PACKAGE_httping-nossl is not set
-# CONFIG_PACKAGE_https-dns-proxy is not set
-# CONFIG_PACKAGE_i2pd is not set
-# CONFIG_PACKAGE_ibrdtn-tools is not set
-# CONFIG_PACKAGE_ibrdtnd is not set
-# CONFIG_PACKAGE_ifstat is not set
 # CONFIG_PACKAGE_iftop is not set
-# CONFIG_PACKAGE_iiod is not set
-# CONFIG_PACKAGE_iotivity is not set
-# CONFIG_PACKAGE_iotivity-cpp is not set
-# CONFIG_PACKAGE_iotivity-example-garage is not set
-# CONFIG_PACKAGE_iotivity-example-simple is not set
-# CONFIG_PACKAGE_iotivity-oic-middle is not set
-# CONFIG_PACKAGE_iotivity-resource-container-hue is not set
-# CONFIG_PACKAGE_iotivity-resource-container-lib is not set
-# CONFIG_PACKAGE_iotivity-resource-container-sample is not set
-# CONFIG_PACKAGE_iotivity-resource-directory-lib is not set
 # CONFIG_PACKAGE_iperf is not set
 # CONFIG_PACKAGE_iperf3 is not set
 # CONFIG_PACKAGE_iperf3-ssl is not set
 # CONFIG_PACKAGE_ipip is not set
 # CONFIG_PACKAGE_ipset is not set
 # CONFIG_PACKAGE_ipset-dns is not set
-# CONFIG_PACKAGE_iptraf-ng is not set
 # CONFIG_PACKAGE_iputils-arping is not set
 # CONFIG_PACKAGE_iputils-clockdiff is not set
 # CONFIG_PACKAGE_iputils-ping is not set
@@ -5192,55 +2797,10 @@ CONFIG_PACKAGE_hostapd-common=y
 # CONFIG_PACKAGE_iputils-tracepath is not set
 # CONFIG_PACKAGE_iputils-tracepath6 is not set
 # CONFIG_PACKAGE_iputils-traceroute6 is not set
-# CONFIG_PACKAGE_ipvsadm is not set
 CONFIG_PACKAGE_iw=y
 # CONFIG_PACKAGE_iw-full is not set
-# CONFIG_PACKAGE_jool is not set
-# CONFIG_PACKAGE_jool-tools is not set
-# CONFIG_PACKAGE_keepalived is not set
-# CONFIG_PACKAGE_knxd is not set
-# CONFIG_PACKAGE_kplex is not set
-# CONFIG_PACKAGE_krb5-client is not set
-# CONFIG_PACKAGE_krb5-libs is not set
-# CONFIG_PACKAGE_krb5-server is not set
-# CONFIG_PACKAGE_krb5-server-extras is not set
 # CONFIG_PACKAGE_libipset is not set
-# CONFIG_PACKAGE_libndp is not set
-# CONFIG_PACKAGE_linknx is not set
-# CONFIG_PACKAGE_lynx is not set
-# CONFIG_PACKAGE_mac-telnet-client is not set
-# CONFIG_PACKAGE_mac-telnet-discover is not set
-# CONFIG_PACKAGE_mac-telnet-ping is not set
-# CONFIG_PACKAGE_mac-telnet-server is not set
 # CONFIG_PACKAGE_map is not set
-# CONFIG_PACKAGE_memcached is not set
-# CONFIG_PACKAGE_mii-tool is not set
-# CONFIG_PACKAGE_mikrotik-btest is not set
-# CONFIG_PACKAGE_mini_snmpd is not set
-# CONFIG_PACKAGE_minimalist-pcproxy is not set
-# CONFIG_PACKAGE_modemmanager is not set
-# CONFIG_PACKAGE_mosquitto-client-nossl is not set
-# CONFIG_PACKAGE_mosquitto-client-ssl is not set
-# CONFIG_PACKAGE_mosquitto-nossl is not set
-# CONFIG_PACKAGE_mosquitto-ssl is not set
-# CONFIG_PACKAGE_mrd6 is not set
-# CONFIG_PACKAGE_mtr is not set
-# CONFIG_PACKAGE_nbd is not set
-# CONFIG_PACKAGE_nbd-server is not set
-# CONFIG_PACKAGE_ncp is not set
-# CONFIG_PACKAGE_ndppd is not set
-# CONFIG_PACKAGE_ndptool is not set
-# CONFIG_PACKAGE_netcat is not set
-# CONFIG_PACKAGE_netdiscover is not set
-# CONFIG_PACKAGE_netifyd is not set
-# CONFIG_PACKAGE_netperf is not set
-# CONFIG_PACKAGE_nextdns is not set
-# CONFIG_PACKAGE_nlbwmon is not set
-# CONFIG_PACKAGE_noping is not set
-# CONFIG_PACKAGE_nut is not set
-# CONFIG_PACKAGE_obfs4proxy is not set
-# CONFIG_PACKAGE_obfsproxy is not set
-# CONFIG_PACKAGE_obfsproxy-src is not set
 CONFIG_PACKAGE_odhcp6c=y
 CONFIG_PACKAGE_odhcp6c_ext_cer_id=0
 # CONFIG_PACKAGE_odhcpd is not set
@@ -5250,16 +2810,7 @@ CONFIG_PACKAGE_odhcpd-ipv6only=y
 # Configuration
 #
 CONFIG_PACKAGE_odhcpd_ipv6only_ext_cer_id=0
-# CONFIG_PACKAGE_ola is not set
 # CONFIG_PACKAGE_omcproxy is not set
-# CONFIG_PACKAGE_oor is not set
-# CONFIG_PACKAGE_oping is not set
-# CONFIG_PACKAGE_pagekitec is not set
-# CONFIG_PACKAGE_pen is not set
-# CONFIG_PACKAGE_phantap is not set
-# CONFIG_PACKAGE_pimbd is not set
-# CONFIG_PACKAGE_pingcheck is not set
-# CONFIG_PACKAGE_port-mirroring is not set
 CONFIG_PACKAGE_ppp=y
 # CONFIG_PACKAGE_ppp-mod-passwordfd is not set
 # CONFIG_PACKAGE_ppp-mod-pppoa is not set
@@ -5270,85 +2821,30 @@ CONFIG_PACKAGE_ppp-mod-pppoe=y
 # CONFIG_PACKAGE_ppp-multilink is not set
 # CONFIG_PACKAGE_pppdump is not set
 # CONFIG_PACKAGE_pppoe-discovery is not set
-# CONFIG_PACKAGE_pppossh is not set
 # CONFIG_PACKAGE_pppstats is not set
-# CONFIG_PACKAGE_proto-bonding is not set
-# CONFIG_PACKAGE_ptunnel-ng is not set
-# CONFIG_PACKAGE_radsecproxy is not set
-# CONFIG_PACKAGE_ratechecker is not set
-# CONFIG_PACKAGE_redsocks is not set
-# CONFIG_PACKAGE_remserial is not set
-# CONFIG_PACKAGE_restic-rest-server is not set
-# CONFIG_PACKAGE_rpcbind is not set
 # CONFIG_PACKAGE_rssileds is not set
-# CONFIG_PACKAGE_rsyslog is not set
-# CONFIG_PACKAGE_safe-search is not set
 # CONFIG_PACKAGE_samba36-client is not set
 # CONFIG_PACKAGE_samba36-hotplug is not set
 # CONFIG_PACKAGE_samba36-net is not set
 # CONFIG_PACKAGE_samba36-server is not set
-# CONFIG_PACKAGE_samba4-admin is not set
-# CONFIG_PACKAGE_samba4-client is not set
-# CONFIG_PACKAGE_samba4-libs is not set
-# CONFIG_PACKAGE_samba4-server is not set
-# CONFIG_PACKAGE_samba4-utils is not set
-# CONFIG_PACKAGE_scapy is not set
-# CONFIG_PACKAGE_sctp-tools is not set
-# CONFIG_PACKAGE_seafile-ccnet is not set
-# CONFIG_PACKAGE_seafile-seahub is not set
-# CONFIG_PACKAGE_seafile-server is not set
-# CONFIG_PACKAGE_ser2net is not set
 # CONFIG_PACKAGE_shellinabox is not set
-# CONFIG_PACKAGE_simple-adblock is not set
-# CONFIG_PACKAGE_smartsnmpd is not set
-# CONFIG_PACKAGE_snmp-mibs is not set
-# CONFIG_PACKAGE_snmp-utils is not set
-# CONFIG_PACKAGE_snmpd is not set
-# CONFIG_PACKAGE_snmptrapd is not set
-# CONFIG_PACKAGE_socat is not set
-# CONFIG_PACKAGE_softflowd is not set
 # CONFIG_PACKAGE_soloscli is not set
-# CONFIG_PACKAGE_speedtest-netperf is not set
-# CONFIG_PACKAGE_spoofer is not set
-# CONFIG_PACKAGE_stunnel is not set
-# CONFIG_PACKAGE_tac_plus is not set
-# CONFIG_PACKAGE_tac_plus-pam is not set
-# CONFIG_PACKAGE_tayga is not set
 # CONFIG_PACKAGE_tcpdump is not set
 # CONFIG_PACKAGE_tcpdump-mini is not set
-# CONFIG_PACKAGE_tgt is not set
-# CONFIG_PACKAGE_tor is not set
-# CONFIG_PACKAGE_tor-fw-helper is not set
-# CONFIG_PACKAGE_tor-gencert is not set
-# CONFIG_PACKAGE_tor-geoip is not set
-# CONFIG_PACKAGE_tor-resolve is not set
-# CONFIG_PACKAGE_trafficshaper is not set
-# CONFIG_PACKAGE_travelmate is not set
-# CONFIG_PACKAGE_u2pnpd is not set
 CONFIG_PACKAGE_uclient-fetch=y
-# CONFIG_PACKAGE_udptunnel is not set
-# CONFIG_PACKAGE_udpxy is not set
-# CONFIG_PACKAGE_ulogd is not set
 # CONFIG_PACKAGE_umbim is not set
 # CONFIG_PACKAGE_umdns is not set
-# CONFIG_PACKAGE_usbip is not set
-# CONFIG_PACKAGE_vallumd is not set
-# CONFIG_PACKAGE_vncrepeater is not set
-# CONFIG_PACKAGE_vnstat is not set
-# CONFIG_PACKAGE_vpn-policy-routing is not set
-# CONFIG_PACKAGE_vpnbypass is not set
 # CONFIG_PACKAGE_vti is not set
 # CONFIG_PACKAGE_vxlan is not set
-# CONFIG_PACKAGE_wakeonlan is not set
 # CONFIG_PACKAGE_wpa-cli is not set
 # CONFIG_PACKAGE_wpa-supplicant is not set
 # CONFIG_WPA_RFKILL_SUPPORT is not set
 CONFIG_WPA_MSG_MIN_PRIORITY=3
 # CONFIG_WPA_WOLFSSL is not set
 # CONFIG_DRIVER_WEXT_SUPPORT is not set
-# CONFIG_DRIVER_11N_SUPPORT is not set
-# CONFIG_DRIVER_11AC_SUPPORT is not set
-# CONFIG_DRIVER_11W_SUPPORT is not set
+CONFIG_DRIVER_11N_SUPPORT=y
+CONFIG_DRIVER_11AC_SUPPORT=y
+CONFIG_DRIVER_11W_SUPPORT=y
 # CONFIG_PACKAGE_wpa-supplicant-basic is not set
 # CONFIG_PACKAGE_wpa-supplicant-mesh-openssl is not set
 # CONFIG_PACKAGE_wpa-supplicant-mesh-wolfssl is not set
@@ -5366,56 +2862,10 @@ CONFIG_PACKAGE_wpad-basic=y
 # CONFIG_PACKAGE_wpad-wolfssl is not set
 # CONFIG_PACKAGE_wpan-tools is not set
 # CONFIG_PACKAGE_wwan is not set
-# CONFIG_PACKAGE_xinetd is not set
-
-#
-# Sound
-#
-# CONFIG_PACKAGE_alsa-utils is not set
-# CONFIG_PACKAGE_alsa-utils-seq is not set
-# CONFIG_PACKAGE_alsa-utils-tests is not set
-# CONFIG_PACKAGE_espeak is not set
-# CONFIG_PACKAGE_faad2 is not set
-# CONFIG_PACKAGE_forked-daapd is not set
-# CONFIG_PACKAGE_ices is not set
-# CONFIG_PACKAGE_lame is not set
-# CONFIG_PACKAGE_lame-lib is not set
-# CONFIG_PACKAGE_liblo-utils is not set
-# CONFIG_PACKAGE_madplay is not set
-# CONFIG_PACKAGE_madplay-alsa is not set
-# CONFIG_PACKAGE_moc is not set
-# CONFIG_PACKAGE_mpc is not set
-# CONFIG_PACKAGE_mpd-avahi-service is not set
-# CONFIG_PACKAGE_mpd-full is not set
-# CONFIG_PACKAGE_mpd-mini is not set
-# CONFIG_PACKAGE_mpg123 is not set
-# CONFIG_PACKAGE_opus-tools is not set
-# CONFIG_PACKAGE_pianod is not set
-# CONFIG_PACKAGE_pianod-client is not set
-# CONFIG_PACKAGE_portaudio is not set
-# CONFIG_PACKAGE_pulseaudio-daemon is not set
-# CONFIG_PACKAGE_pulseaudio-daemon-avahi is not set
-# CONFIG_PACKAGE_shairplay is not set
-# CONFIG_PACKAGE_shairport-sync-mbedtls is not set
-# CONFIG_PACKAGE_shairport-sync-mini is not set
-# CONFIG_PACKAGE_shairport-sync-openssl is not set
-# CONFIG_PACKAGE_shine is not set
-# CONFIG_PACKAGE_sox is not set
-# CONFIG_PACKAGE_squeezelite-full is not set
-# CONFIG_PACKAGE_squeezelite-mini is not set
-# CONFIG_PACKAGE_svox is not set
-# CONFIG_PACKAGE_upmpdcli is not set
 
 #
 # Utilities
 #
-
-#
-# BigClown
-#
-# CONFIG_PACKAGE_bigclown-control-tool is not set
-# CONFIG_PACKAGE_bigclown-firmware-tool is not set
-# CONFIG_PACKAGE_bigclown-mqtt2influxdb is not set
 
 #
 # Boot Loaders
@@ -5426,18 +2876,7 @@ CONFIG_PACKAGE_wpad-basic=y
 #
 # Compression
 #
-# CONFIG_PACKAGE_bsdtar is not set
-# CONFIG_PACKAGE_bsdtar-noopenssl is not set
 # CONFIG_PACKAGE_bzip2 is not set
-# CONFIG_PACKAGE_gzip is not set
-# CONFIG_PACKAGE_lz4 is not set
-# CONFIG_PACKAGE_unrar is not set
-# CONFIG_PACKAGE_unzip is not set
-# CONFIG_PACKAGE_xz-utils is not set
-# CONFIG_PACKAGE_zipcmp is not set
-# CONFIG_PACKAGE_zipmerge is not set
-# CONFIG_PACKAGE_ziptool is not set
-# CONFIG_PACKAGE_zstd is not set
 
 #
 # Disc
@@ -5446,63 +2885,27 @@ CONFIG_PACKAGE_wpad-basic=y
 # CONFIG_PACKAGE_blkid is not set
 # CONFIG_PACKAGE_blockdev is not set
 # CONFIG_PACKAGE_cfdisk is not set
-# CONFIG_PACKAGE_cgdisk is not set
 # CONFIG_PACKAGE_eject is not set
 # CONFIG_PACKAGE_fdisk is not set
 # CONFIG_PACKAGE_findfs is not set
-# CONFIG_PACKAGE_fio is not set
-# CONFIG_PACKAGE_fixparts is not set
-# CONFIG_PACKAGE_gdisk is not set
-# CONFIG_PACKAGE_hd-idle is not set
-# CONFIG_PACKAGE_hdparm is not set
 # CONFIG_PACKAGE_lsblk is not set
-# CONFIG_PACKAGE_lvm2 is not set
 # CONFIG_PACKAGE_mdadm is not set
 # CONFIG_PACKAGE_partx-utils is not set
 # CONFIG_PACKAGE_sfdisk is not set
-# CONFIG_PACKAGE_sgdisk is not set
 # CONFIG_PACKAGE_wipefs is not set
-
-#
-# Editors
-#
-# CONFIG_PACKAGE_joe is not set
-# CONFIG_PACKAGE_jupp is not set
-# CONFIG_PACKAGE_mg is not set
-# CONFIG_PACKAGE_nano is not set
-# CONFIG_PACKAGE_nano-full is not set
-# CONFIG_PACKAGE_nano-plus is not set
-# CONFIG_PACKAGE_vim is not set
-# CONFIG_PACKAGE_vim-full is not set
-# CONFIG_PACKAGE_vim-fuller is not set
-# CONFIG_PACKAGE_vim-help is not set
-# CONFIG_PACKAGE_vim-runtime is not set
-# CONFIG_PACKAGE_zile is not set
 
 #
 # Encryption
 #
-# CONFIG_PACKAGE_ccrypt is not set
-# CONFIG_PACKAGE_certtool is not set
-# CONFIG_PACKAGE_cryptsetup is not set
-# CONFIG_PACKAGE_gnupg is not set
-# CONFIG_PACKAGE_gnutls-utils is not set
-# CONFIG_PACKAGE_gpgv is not set
-# CONFIG_PACKAGE_keyctl is not set
 # CONFIG_PACKAGE_px5g-mbedtls is not set
 # CONFIG_PACKAGE_px5g-standalone is not set
-# CONFIG_PACKAGE_stoken is not set
 
 #
 # Filesystem
 #
-# CONFIG_PACKAGE_acl is not set
-# CONFIG_PACKAGE_attr is not set
 # CONFIG_PACKAGE_badblocks is not set
-# CONFIG_PACKAGE_btrfs-progs is not set
 # CONFIG_PACKAGE_chattr is not set
 # CONFIG_PACKAGE_debugfs is not set
-# CONFIG_PACKAGE_dosfstools is not set
 # CONFIG_PACKAGE_dumpe2fs is not set
 # CONFIG_PACKAGE_e2freefrag is not set
 # CONFIG_PACKAGE_e2fsprogs is not set
@@ -5512,21 +2915,9 @@ CONFIG_PACKAGE_wpad-basic=y
 # CONFIG_PACKAGE_filefrag is not set
 # CONFIG_PACKAGE_fstrim is not set
 # CONFIG_PACKAGE_fuse-utils is not set
-# CONFIG_PACKAGE_hfsfsck is not set
 # CONFIG_PACKAGE_lsattr is not set
 # CONFIG_PACKAGE_mkf2fs is not set
-# CONFIG_PACKAGE_mkhfs is not set
-# CONFIG_PACKAGE_ncdu is not set
-# CONFIG_PACKAGE_nfs-utils is not set
-# CONFIG_PACKAGE_nfs-utils-libs is not set
-# CONFIG_PACKAGE_ntfs-3g is not set
-# CONFIG_PACKAGE_ntfs-3g-low is not set
-# CONFIG_PACKAGE_ntfs-3g-utils is not set
-# CONFIG_PACKAGE_owfs is not set
-# CONFIG_PACKAGE_owshell is not set
 # CONFIG_PACKAGE_resize2fs is not set
-# CONFIG_PACKAGE_squashfs-tools-mksquashfs is not set
-# CONFIG_PACKAGE_squashfs-tools-unsquashfs is not set
 # CONFIG_PACKAGE_swap-utils is not set
 # CONFIG_PACKAGE_sysfsutils is not set
 # CONFIG_PACKAGE_tune2fs is not set
@@ -5536,332 +2927,63 @@ CONFIG_PACKAGE_wpad-basic=y
 # CONFIG_PACKAGE_xfs-mkfs is not set
 
 #
-# Image Manipulation
-#
-# CONFIG_PACKAGE_jpeg-tools is not set
-# CONFIG_PACKAGE_tiff-utils is not set
-
-#
-# Microcontroller programming
-#
-# CONFIG_PACKAGE_avrdude is not set
-# CONFIG_PACKAGE_dfu-programmer is not set
-# CONFIG_PACKAGE_stm32flash is not set
-
-#
-# RTKLIB Suite
-#
-# CONFIG_PACKAGE_convbin is not set
-# CONFIG_PACKAGE_pos2kml is not set
-# CONFIG_PACKAGE_rnx2rtkp is not set
-# CONFIG_PACKAGE_rtkrcv is not set
-# CONFIG_PACKAGE_str2str is not set
-
-#
-# Shells
-#
-# CONFIG_PACKAGE_bash is not set
-# CONFIG_PACKAGE_fish is not set
-# CONFIG_PACKAGE_klish is not set
-# CONFIG_PACKAGE_mksh is not set
-# CONFIG_PACKAGE_tcsh is not set
-# CONFIG_PACKAGE_zsh is not set
-
-#
-# Telephony
-#
-# CONFIG_PACKAGE_dahdi-cfg is not set
-# CONFIG_PACKAGE_dahdi-monitor is not set
-# CONFIG_PACKAGE_gsm-utils is not set
-# CONFIG_PACKAGE_sipgrep is not set
-# CONFIG_PACKAGE_sngrep is not set
-
-#
 # Terminal
 #
 # CONFIG_PACKAGE_agetty is not set
-# CONFIG_PACKAGE_dvtm is not set
-# CONFIG_PACKAGE_minicom is not set
-# CONFIG_PACKAGE_picocom is not set
-# CONFIG_PACKAGE_rtty-mbedtls is not set
-# CONFIG_PACKAGE_rtty-nossl is not set
-# CONFIG_PACKAGE_rtty-openssl is not set
-# CONFIG_PACKAGE_rtty-wolfssl is not set
-# CONFIG_PACKAGE_screen is not set
 # CONFIG_PACKAGE_script-utils is not set
-# CONFIG_PACKAGE_serialconsole is not set
 # CONFIG_PACKAGE_setterm is not set
-# CONFIG_PACKAGE_tio is not set
-# CONFIG_PACKAGE_tmux is not set
-# CONFIG_PACKAGE_ttyd is not set
 # CONFIG_PACKAGE_wall is not set
-
-#
-# Virtualization
-#
-
-#
-# Zoneinfo
-#
-# CONFIG_PACKAGE_zoneinfo-africa is not set
-# CONFIG_PACKAGE_zoneinfo-all is not set
-# CONFIG_PACKAGE_zoneinfo-asia is not set
-# CONFIG_PACKAGE_zoneinfo-atlantic is not set
-# CONFIG_PACKAGE_zoneinfo-australia-nz is not set
-# CONFIG_PACKAGE_zoneinfo-core is not set
-# CONFIG_PACKAGE_zoneinfo-europe is not set
-# CONFIG_PACKAGE_zoneinfo-india is not set
-# CONFIG_PACKAGE_zoneinfo-northamerica is not set
-# CONFIG_PACKAGE_zoneinfo-pacific is not set
-# CONFIG_PACKAGE_zoneinfo-poles is not set
-# CONFIG_PACKAGE_zoneinfo-simple is not set
-# CONFIG_PACKAGE_zoneinfo-southamerica is not set
-
-#
-# database
-#
-# CONFIG_PACKAGE_mariadb-common is not set
-# CONFIG_PACKAGE_pgsql-cli is not set
-# CONFIG_PACKAGE_pgsql-cli-extra is not set
-# CONFIG_PACKAGE_pgsql-server is not set
-# CONFIG_PACKAGE_rrdcgi1 is not set
-# CONFIG_PACKAGE_rrdtool1 is not set
-# CONFIG_PACKAGE_sqlite3-cli is not set
-# CONFIG_PACKAGE_unixodbc-tools is not set
-
-#
-# libimobiledevice
-#
-# CONFIG_PACKAGE_idevicerestore is not set
-# CONFIG_PACKAGE_irecovery is not set
-# CONFIG_PACKAGE_libimobiledevice-utils is not set
-# CONFIG_PACKAGE_libusbmuxd-utils is not set
-# CONFIG_PACKAGE_plistutil is not set
-# CONFIG_PACKAGE_usbmuxd is not set
-# CONFIG_PACKAGE_acpid is not set
 # CONFIG_PACKAGE_adb is not set
-# CONFIG_PACKAGE_ap51-flash is not set
-# CONFIG_PACKAGE_at is not set
-# CONFIG_PACKAGE_bandwidthd is not set
-# CONFIG_PACKAGE_bandwidthd-pgsql is not set
-# CONFIG_PACKAGE_bandwidthd-php is not set
-# CONFIG_PACKAGE_bandwidthd-sqlite is not set
-# CONFIG_PACKAGE_banhostlist is not set
-# CONFIG_PACKAGE_bc is not set
-# CONFIG_PACKAGE_bluelog is not set
-# CONFIG_PACKAGE_bluez-daemon is not set
-# CONFIG_PACKAGE_bluez-utils is not set
-# CONFIG_PACKAGE_bonniexx is not set
 # CONFIG_PACKAGE_bsdiff is not set
 # CONFIG_PACKAGE_bspatch is not set
-# CONFIG_PACKAGE_byobu is not set
-# CONFIG_PACKAGE_byobu-utils is not set
 # CONFIG_PACKAGE_cal is not set
-# CONFIG_PACKAGE_canutils is not set
-# CONFIG_PACKAGE_cgroup-tools is not set
-# CONFIG_PACKAGE_cmdpad is not set
-# CONFIG_PACKAGE_coap-client is not set
-# CONFIG_PACKAGE_collectd is not set
-# CONFIG_PACKAGE_coreutils is not set
-# CONFIG_PACKAGE_crconf is not set
-# CONFIG_PACKAGE_crelay is not set
-# CONFIG_PACKAGE_csstidy is not set
 # CONFIG_PACKAGE_ct-bugcheck is not set
-# CONFIG_PACKAGE_dbus is not set
-# CONFIG_PACKAGE_dbus-utils is not set
-# CONFIG_PACKAGE_device-observatory is not set
-# CONFIG_PACKAGE_dfu-util is not set
-# CONFIG_PACKAGE_digitemp is not set
-# CONFIG_PACKAGE_digitemp-usb is not set
 # CONFIG_PACKAGE_dmesg is not set
 # CONFIG_PACKAGE_dosbox is not set
 # CONFIG_PACKAGE_dropbearconvert is not set
-# CONFIG_PACKAGE_dtc is not set
-# CONFIG_PACKAGE_dump1090 is not set
-# CONFIG_PACKAGE_ecdsautils is not set
-# CONFIG_PACKAGE_elektra-kdb is not set
-# CONFIG_PACKAGE_evtest is not set
-# CONFIG_PACKAGE_extract is not set
-# CONFIG_PACKAGE_fdt-utils is not set
-# CONFIG_PACKAGE_file is not set
-# CONFIG_PACKAGE_findutils is not set
-# CONFIG_PACKAGE_findutils-find is not set
-# CONFIG_PACKAGE_findutils-locate is not set
-# CONFIG_PACKAGE_findutils-xargs is not set
-# CONFIG_PACKAGE_flashrom is not set
-# CONFIG_PACKAGE_flashrom-pci is not set
-# CONFIG_PACKAGE_flashrom-spi is not set
-# CONFIG_PACKAGE_flashrom-usb is not set
-# CONFIG_PACKAGE_flent-tools is not set
+# CONFIG_PACKAGE_fbtest is not set
 # CONFIG_PACKAGE_flock is not set
 # CONFIG_PACKAGE_fritz-caldata is not set
 # CONFIG_PACKAGE_fritz-tffs is not set
 # CONFIG_PACKAGE_fritz-tffs-nand is not set
 # CONFIG_PACKAGE_ftdi_eeprom is not set
-# CONFIG_PACKAGE_gammu is not set
-# CONFIG_PACKAGE_gawk is not set
-# CONFIG_PACKAGE_gddrescue is not set
 # CONFIG_PACKAGE_getopt is not set
-# CONFIG_PACKAGE_gkermit is not set
-# CONFIG_PACKAGE_gpioctl-sysfs is not set
-# CONFIG_PACKAGE_gpiod-tools is not set
-# CONFIG_PACKAGE_gpsd is not set
-# CONFIG_PACKAGE_gpsd-clients is not set
-# CONFIG_PACKAGE_grep is not set
-# CONFIG_PACKAGE_hamlib is not set
-# CONFIG_PACKAGE_haserl is not set
-# CONFIG_PACKAGE_hashdeep is not set
-# CONFIG_PACKAGE_haveged is not set
-# CONFIG_PACKAGE_hplip-common is not set
-# CONFIG_PACKAGE_hplip-sane is not set
-# CONFIG_PACKAGE_hub-ctrl is not set
 # CONFIG_PACKAGE_hwclock is not set
-# CONFIG_PACKAGE_hwloc-utils is not set
-# CONFIG_PACKAGE_i2c-tools is not set
+CONFIG_PACKAGE_i2c-tools=y
 # CONFIG_PACKAGE_iconv is not set
-# CONFIG_PACKAGE_iio-utils is not set
-# CONFIG_PACKAGE_inotifywait is not set
-# CONFIG_PACKAGE_inotifywatch is not set
-# CONFIG_PACKAGE_io is not set
-# CONFIG_PACKAGE_irqbalance is not set
 # CONFIG_PACKAGE_iwcap is not set
 CONFIG_PACKAGE_iwinfo=y
-# CONFIG_PACKAGE_jq is not set
 CONFIG_PACKAGE_jshn=y
-# CONFIG_PACKAGE_kmod is not set
-# CONFIG_PACKAGE_lcd4linux-custom is not set
-# CONFIG_PACKAGE_lcdproc-clients is not set
-# CONFIG_PACKAGE_lcdproc-drivers is not set
-# CONFIG_PACKAGE_lcdproc-server is not set
-# CONFIG_PACKAGE_less is not set
-# CONFIG_PACKAGE_less-wide is not set
 CONFIG_PACKAGE_libjson-script=y
-# CONFIG_PACKAGE_libsysrepo is not set
-# CONFIG_PACKAGE_lm-sensors is not set
-# CONFIG_PACKAGE_lm-sensors-detect is not set
 # CONFIG_PACKAGE_logger is not set
-# CONFIG_PACKAGE_logrotate is not set
 # CONFIG_PACKAGE_look is not set
 # CONFIG_PACKAGE_losetup is not set
-# CONFIG_PACKAGE_lrzsz is not set
 # CONFIG_PACKAGE_lscpu is not set
-# CONFIG_PACKAGE_lsof is not set
-# CONFIG_PACKAGE_lxc is not set
-# CONFIG_PACKAGE_lxc-unprivileged is not set
 # CONFIG_PACKAGE_maccalc is not set
-# CONFIG_PACKAGE_macchanger is not set
 # CONFIG_PACKAGE_mbedtls-util is not set
-# CONFIG_PACKAGE_mbim-utils is not set
-# CONFIG_PACKAGE_mbtools is not set
-# CONFIG_PACKAGE_mc is not set
 # CONFIG_PACKAGE_mcookie is not set
-# CONFIG_PACKAGE_micrond is not set
-# CONFIG_PACKAGE_mmc-utils is not set
-# CONFIG_PACKAGE_moreutils is not set
-# CONFIG_PACKAGE_mosh-client is not set
-# CONFIG_PACKAGE_mosh-server is not set
 # CONFIG_PACKAGE_mount-utils is not set
-# CONFIG_PACKAGE_mpack is not set
-# CONFIG_PACKAGE_mt-st is not set
 # CONFIG_PACKAGE_namei is not set
-# CONFIG_PACKAGE_netopeer2-cli is not set
-# CONFIG_PACKAGE_netopeer2-keystored is not set
-# CONFIG_PACKAGE_netopeer2-server is not set
-# CONFIG_PACKAGE_netwhere is not set
-# CONFIG_PACKAGE_nnn is not set
 # CONFIG_PACKAGE_nsenter is not set
-# CONFIG_PACKAGE_nss-utils is not set
-# CONFIG_PACKAGE_oath-toolkit is not set
-# CONFIG_PACKAGE_open-plc-utils is not set
-# CONFIG_PACKAGE_open2300 is not set
-# CONFIG_PACKAGE_openobex is not set
-# CONFIG_PACKAGE_openobex-apps is not set
 # CONFIG_PACKAGE_openocd is not set
-# CONFIG_PACKAGE_opensc-utils is not set
 # CONFIG_PACKAGE_openssl-util is not set
-# CONFIG_PACKAGE_openzwave is not set
-# CONFIG_PACKAGE_openzwave-config is not set
 # CONFIG_PACKAGE_owipcalc is not set
 # CONFIG_PACKAGE_paho.mqtt.c is not set
-# CONFIG_PACKAGE_pciutils is not set
-# CONFIG_PACKAGE_pcsc-tools is not set
-# CONFIG_PACKAGE_pcscd is not set
-# CONFIG_PACKAGE_powertop is not set
-# CONFIG_PACKAGE_pps-tools is not set
 # CONFIG_PACKAGE_prlimit is not set
-# CONFIG_PACKAGE_procps-ng is not set
-# CONFIG_PACKAGE_progress is not set
-# CONFIG_PACKAGE_prometheus is not set
-# CONFIG_PACKAGE_prometheus-node-exporter-lua is not set
-# CONFIG_PACKAGE_prometheus-statsd-exporter is not set
-# CONFIG_PACKAGE_pv is not set
-# CONFIG_PACKAGE_qmi-utils is not set
-# CONFIG_PACKAGE_qrencode is not set
-# CONFIG_PACKAGE_relayctl is not set
 # CONFIG_PACKAGE_rename is not set
-# CONFIG_PACKAGE_restic is not set
-# CONFIG_PACKAGE_rng-tools is not set
-# CONFIG_PACKAGE_rtl-ais is not set
-# CONFIG_PACKAGE_rtl-sdr is not set
-# CONFIG_PACKAGE_rtl_433 is not set
-# CONFIG_PACKAGE_sane-daemon is not set
-# CONFIG_PACKAGE_sane-frontends is not set
-# CONFIG_PACKAGE_setserial is not set
-# CONFIG_PACKAGE_shadow-utils is not set
-# CONFIG_PACKAGE_shinit is not set
-# CONFIG_PACKAGE_sispmctl is not set
-# CONFIG_PACKAGE_slide-switch is not set
-# CONFIG_PACKAGE_smartd is not set
-# CONFIG_PACKAGE_smartmontools is not set
-# CONFIG_PACKAGE_smartmontools-drivedb is not set
-# CONFIG_PACKAGE_smstools3 is not set
-# CONFIG_PACKAGE_sockread is not set
-# CONFIG_PACKAGE_spi-tools is not set
 # CONFIG_PACKAGE_spidev-test is not set
-# CONFIG_PACKAGE_ssdeep is not set
-# CONFIG_PACKAGE_sshpass is not set
 # CONFIG_PACKAGE_strace is not set
 CONFIG_STRACE_NONE=y
 # CONFIG_STRACE_LIBDW is not set
 # CONFIG_STRACE_LIBUNWIND is not set
-# CONFIG_PACKAGE_stress is not set
-# CONFIG_PACKAGE_sumo is not set
-# CONFIG_PACKAGE_syncthing is not set
-# CONFIG_PACKAGE_sysrepo is not set
-# CONFIG_PACKAGE_sysrepocfg is not set
-# CONFIG_PACKAGE_sysrepoctl is not set
-# CONFIG_PACKAGE_sysstat is not set
-# CONFIG_PACKAGE_tar is not set
-# CONFIG_PACKAGE_taskwarrior is not set
-# CONFIG_PACKAGE_telldus-core is not set
-# CONFIG_PACKAGE_temperusb is not set
-# CONFIG_PACKAGE_tracertools is not set
-# CONFIG_PACKAGE_tree is not set
-# CONFIG_PACKAGE_triggerhappy is not set
-# CONFIG_PACKAGE_udns-dnsget is not set
-# CONFIG_PACKAGE_udns-ex-rdns is not set
-# CONFIG_PACKAGE_udns-rblcheck is not set
 # CONFIG_PACKAGE_ugps is not set
-# CONFIG_PACKAGE_uledd is not set
 # CONFIG_PACKAGE_unshare is not set
 # CONFIG_PACKAGE_usb-modeswitch is not set
 # CONFIG_PACKAGE_usbreset is not set
 # CONFIG_PACKAGE_usbutils is not set
 # CONFIG_PACKAGE_uuidd is not set
 # CONFIG_PACKAGE_uuidgen is not set
-# CONFIG_PACKAGE_uvcdynctrl is not set
-# CONFIG_PACKAGE_v4l-utils is not set
-# CONFIG_PACKAGE_view1090 is not set
-# CONFIG_PACKAGE_watchcat is not set
 # CONFIG_PACKAGE_whereis is not set
-# CONFIG_PACKAGE_whiptail is not set
-# CONFIG_PACKAGE_wifitoggle is not set
-# CONFIG_PACKAGE_xsltproc is not set
-# CONFIG_PACKAGE_xxd is not set
-# CONFIG_PACKAGE_yanglint is not set
-# CONFIG_PACKAGE_yara is not set
-# CONFIG_PACKAGE_ykpers is not set
-# CONFIG_PACKAGE_yunbridge is not set
 
 #
 # VoCore2
@@ -5869,19 +2991,3 @@ CONFIG_STRACE_NONE=y
 # CONFIG_PACKAGE_ated is not set
 # CONFIG_PACKAGE_kmod-fbusb is not set
 # CONFIG_PACKAGE_mem is not set
-
-#
-# Xorg
-#
-
-#
-# font-utils
-#
-# CONFIG_PACKAGE_fontconfig is not set
-CONFIG_OVERRIDE_PKGS="ffmpeg hidapi i2c-tools libftdi1 openocd"
-
-#
-# Inspectron
-#
-CONFIG_PACKAGE_wifiHandleController=y
-


### PR DESCRIPTION
- Updated insp_config. It now has correct target profile, and qt library included
- For further builds, we can just copy insp_config to .config without using _make menuconfig_