### PR TITLE
Update i2c patch

### DIFF
--- a/target/linux/ramips/patches-4.14/0045-i2c-add-mt7621-driver.patch
+++ b/target/linux/ramips/patches-4.14/0045-i2c-add-mt7621-driver.patch
@@ -1,33 +1,43 @@
-From d5c54ff3d1db0a4348fa04d8e78f3bf6063e3afc Mon Sep 17 00:00:00 2001
-From: John Crispin <blogic@openwrt.org>
-Date: Mon, 7 Dec 2015 17:21:27 +0100
-Subject: [PATCH 45/53] i2c: add mt7621 driver
+From de08bb2724b88c1441f2769704bb6dca1baf735c Mon Sep 17 00:00:00 2001
+From: nop <nop@nop.nop>
+Date: Mon, 20 Feb 2023 09:29:42 +0800
+Subject: [PATCH] drivers/i2c/busses: add i2c-mt7628
 
-Signed-off-by: John Crispin <blogic@openwrt.org>
 ---
- drivers/i2c/busses/Kconfig      |    4 +
- drivers/i2c/busses/Makefile     |    1 +
- drivers/i2c/busses/i2c-mt7621.c |  303 +++++++++++++++++++++++++++++++++++++++
- 3 files changed, 308 insertions(+)
+ drivers/i2c/busses/Kconfig      |   6 +
+ drivers/i2c/busses/Makefile     |   1 +
+ drivers/i2c/busses/i2c-mt7621.c | 363 ++++++++++++++++++++++++++++++++
+ 3 files changed, 370 insertions(+)
  create mode 100644 drivers/i2c/busses/i2c-mt7621.c
 
+diff --git a/drivers/i2c/busses/Kconfig b/drivers/i2c/busses/Kconfig
+index c457f651..4c42896c 100644
 --- a/drivers/i2c/busses/Kconfig
 +++ b/drivers/i2c/busses/Kconfig
-@@ -869,6 +869,11 @@ config I2C_RALINK
- 	depends on RALINK && !SOC_MT7621
- 	select OF_I2C
+@@ -1319,6 +1319,11 @@ config I2C_OPAL
+ 	  This driver can also be built as a module. If so, the module will be
+ 	  called as i2c-opal.
  
 +config I2C_MT7621
-+	tristate "MT7621/MT7628 I2C Controller"
-+	depends on RALINK && (SOC_MT7620 || SOC_MT7621)
-+	select OF_I2C
++        tristate "MT7621/MT7628 I2C Controller"
++        depends on RALINK && (SOC_MT7620 || SOC_MT7621)
++        select OF_I2C
 +
- config HAVE_S3C2410_I2C
- 	bool
- 	help
+ config I2C_ZX2967
+ 	tristate "ZTE ZX2967 I2C support"
+ 	depends on ARCH_ZX
+@@ -1328,4 +1333,5 @@ config I2C_ZX2967
+ 	  This driver can also be built as a module. If so, the module will be
+ 	  called i2c-zx2967.
+ 
++
+ endmenu
+diff --git a/drivers/i2c/busses/Makefile b/drivers/i2c/busses/Makefile
+index 2ce85765..aaec54c4 100644
 --- a/drivers/i2c/busses/Makefile
 +++ b/drivers/i2c/busses/Makefile
-@@ -85,6 +85,7 @@ obj-$(CONFIG_I2C_PUV3)		+= i2c-puv3.o
+@@ -84,6 +84,7 @@ obj-$(CONFIG_I2C_PNX)		+= i2c-pnx.o
+ obj-$(CONFIG_I2C_PUV3)		+= i2c-puv3.o
  obj-$(CONFIG_I2C_PXA)		+= i2c-pxa.o
  obj-$(CONFIG_I2C_PXA_PCI)	+= i2c-pxa-pci.o
  obj-$(CONFIG_I2C_RALINK)	+= i2c-ralink.o
@@ -35,302 +45,248 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  obj-$(CONFIG_I2C_QUP)		+= i2c-qup.o
  obj-$(CONFIG_I2C_RIIC)		+= i2c-riic.o
  obj-$(CONFIG_I2C_RK3X)		+= i2c-rk3x.o
+diff --git a/drivers/i2c/busses/i2c-mt7621.c b/drivers/i2c/busses/i2c-mt7621.c
+new file mode 100644
+index 00000000..777235fc
 --- /dev/null
 +++ b/drivers/i2c/busses/i2c-mt7621.c
-@@ -0,0 +1,433 @@
+@@ -0,0 +1,363 @@
++// SPDX-License-Identifier: GPL-2.0
 +/*
 + * drivers/i2c/busses/i2c-mt7621.c
 + *
 + * Copyright (C) 2013 Steven Liu <steven_liu@mediatek.com>
 + * Copyright (C) 2016 Michael Lee <igvtee@gmail.com>
++ * Copyright (C) 2018 Jan Breuer <jan.breuer@jaybee.cz>
 + *
 + * Improve driver for i2cdetect from i2c-tools to detect i2c devices on the bus.
 + * (C) 2014 Sittisak <sittisaks@hotmail.com>
-+ *
-+ * This software is licensed under the terms of the GNU General Public
-+ * License version 2, as published by the Free Software Foundation, and
-+ * may be copied, distributed, and modified under those terms.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
 + */
 +
-+#include <linux/interrupt.h>
-+#include <linux/kernel.h>
-+#include <linux/module.h>
-+#include <linux/reset.h>
++#include <linux/clk.h>
 +#include <linux/delay.h>
-+#include <linux/slab.h>
-+#include <linux/init.h>
-+#include <linux/errno.h>
-+#include <linux/platform_device.h>
-+#include <linux/of_platform.h>
 +#include <linux/i2c.h>
 +#include <linux/io.h>
-+#include <linux/err.h>
-+#include <linux/clk.h>
++#include <linux/iopoll.h>
++#include <linux/module.h>
++#include <linux/of_platform.h>
++#include <linux/reset.h>
 +
-+#define REG_SM0CFG0		0x08
-+#define REG_SM0DOUT		0x10
-+#define REG_SM0DIN		0x14
-+#define REG_SM0ST		0x18
-+#define REG_SM0AUTO		0x1C
-+#define REG_SM0CFG1		0x20
-+#define REG_SM0CFG2		0x28
-+#define REG_SM0CTL0		0x40
-+#define REG_SM0CTL1		0x44
-+#define REG_SM0D0		0x50
-+#define REG_SM0D1		0x54
-+#define REG_PINTEN		0x5C
-+#define REG_PINTST		0x60
-+#define REG_PINTCL		0x64
++#define I2C_MAX_STANDARD_MODE_FREQ	400000
++#define REG_SM0CFG2_REG		0x28
++#define REG_SM0CTL0_REG		0x40
++#define REG_SM0CTL1_REG		0x44
++#define REG_SM0D0_REG		0x50
++#define REG_SM0D1_REG		0x54
++#define REG_PINTEN_REG		0x5c
++#define REG_PINTST_REG		0x60
++#define REG_PINTCL_REG		0x64
 +
-+/* REG_SM0CFG0 */
-+#define I2C_DEVADDR_MASK	0x7f
++/* REG_SM0CFG2_REG */
++#define SM0CFG2_IS_AUTOMODE	BIT(0)
 +
-+/* REG_SM0ST */
-+#define I2C_DATARDY		BIT(2)
-+#define I2C_SDOEMPTY		BIT(1)
-+#define I2C_BUSY		BIT(0)
++/* REG_SM0CTL0_REG */
++#define SM0CTL0_ODRAIN		BIT(31)
++#define SM0CTL0_CLK_DIV_MASK	(0x7ff << 16)
++#define SM0CTL0_CLK_DIV_MAX	0x7ff
++#define SM0CTL0_CS_STATUS       BIT(4)
++#define SM0CTL0_SCL_STATE       BIT(3)
++#define SM0CTL0_SDA_STATE       BIT(2)
++#define SM0CTL0_EN              BIT(1)
++#define SM0CTL0_SCL_STRETCH     BIT(0)
 +
-+/* REG_SM0AUTO */
-+#define READ_CMD		BIT(0)
++/* REG_SM0CTL1_REG */
++#define SM0CTL1_ACK_MASK	(0xff << 16)
++#define SM0CTL1_PGLEN_MASK	(0x7 << 8)
++#define SM0CTL1_PGLEN(x)	((((x) - 1) << 8) & SM0CTL1_PGLEN_MASK)
++#define SM0CTL1_READ		(5 << 4)
++#define SM0CTL1_READ_LAST	(4 << 4)
++#define SM0CTL1_STOP		(3 << 4)
++#define SM0CTL1_WRITE		(2 << 4)
++#define SM0CTL1_START		(1 << 4)
++#define SM0CTL1_MODE_MASK	(0x7 << 4)
++#define SM0CTL1_TRI		BIT(0)
 +
-+/* REG_SM0CFG1 */
-+#define BYTECNT_MAX		64
-+#define SET_BYTECNT(x)		(x - 1)
-+
-+/* REG_SM0CFG2 */
-+#define AUTOMODE_EN		BIT(0)
-+
-+/* REG_SM0CTL0 */
-+#define ODRAIN_HIGH_SM0		BIT(31)
-+#define VSYNC_SHIFT		28
-+#define VSYNC_MASK		0x3
-+#define VSYNC_PULSE		(0x1 << VSYNC_SHIFT)
-+#define VSYNC_RISING		(0x2 << VSYNC_SHIFT)
-+#define CLK_DIV_SHIFT		16
-+#define CLK_DIV_MASK		0xfff
-+#define DEG_CNT_SHIFT		8
-+#define DEG_CNT_MASK		0xff
-+#define WAIT_HIGH		BIT(6)
-+#define DEG_EN			BIT(5)
-+#define CS_STATUA		BIT(4)
-+#define SCL_STATUS		BIT(3)
-+#define SDA_STATUS		BIT(2)
-+#define SM0_EN			BIT(1)
-+#define SCL_STRECH		BIT(0)
-+
-+/* REG_SM0CTL1 */
-+#define ACK_SHIFT		16
-+#define ACK_MASK		0xff
-+#define PGLEN_SHIFT		8
-+#define PGLEN_MASK		0x7
-+#define SM0_MODE_SHIFT		4
-+#define SM0_MODE_MASK		0x7
-+#define SM0_MODE_START		0x1
-+#define SM0_MODE_WRITE		0x2
-+#define SM0_MODE_STOP		0x3
-+#define SM0_MODE_READ_NACK	0x4
-+#define SM0_MODE_READ_ACK	0x5
-+#define SM0_TRI_BUSY		BIT(0)
-+
-+/* timeout waiting for I2C devices to respond (clock streching) */
-+#define TIMEOUT_MS              1000
-+#define DELAY_INTERVAL_US       100
++/* timeout waiting for I2C devices to respond */
++#define TIMEOUT_MS		1000
 +
 +struct mtk_i2c {
 +	void __iomem *base;
-+	struct clk *clk;
 +	struct device *dev;
 +	struct i2c_adapter adap;
-+	u32 cur_clk;
++	u32 bus_freq;
 +	u32 clk_div;
 +	u32 flags;
++	struct clk *clk;
 +};
-+
-+static void mtk_i2c_w32(struct mtk_i2c *i2c, u32 val, unsigned reg)
-+{
-+	iowrite32(val, i2c->base + reg);
-+}
-+
-+static u32 mtk_i2c_r32(struct mtk_i2c *i2c, unsigned reg)
-+{
-+	return ioread32(i2c->base + reg);
-+}
-+
-+static int poll_down_timeout(void __iomem *addr, u32 mask)
-+{
-+	unsigned long timeout = jiffies + msecs_to_jiffies(TIMEOUT_MS);
-+
-+	do {
-+		if (!(readl_relaxed(addr) & mask))
-+			return 0;
-+
-+		usleep_range(DELAY_INTERVAL_US, DELAY_INTERVAL_US + 50);
-+	} while (time_before(jiffies, timeout));
-+
-+	return (readl_relaxed(addr) & mask) ? -EAGAIN : 0;
-+}
 +
 +static int mtk_i2c_wait_idle(struct mtk_i2c *i2c)
 +{
 +	int ret;
++	u32 val;
 +
-+	ret = poll_down_timeout(i2c->base + REG_SM0ST, I2C_BUSY);
-+	if (ret < 0)
++	ret = readl_relaxed_poll_timeout(i2c->base + REG_SM0CTL1_REG,
++					 val, !(val & SM0CTL1_TRI),
++					 10, TIMEOUT_MS * 1000);
++	if (ret)
 +		dev_dbg(i2c->dev, "idle err(%d)\n", ret);
-+
-+	return ret;
-+}
-+
-+static int poll_up_timeout(void __iomem *addr, u32 mask)
-+{
-+	unsigned long timeout = jiffies + msecs_to_jiffies(TIMEOUT_MS);
-+	u32 status;
-+
-+	do {
-+		status = readl_relaxed(addr);
-+		if (status & mask)
-+			return 0;
-+		usleep_range(DELAY_INTERVAL_US, DELAY_INTERVAL_US + 50);
-+	} while (time_before(jiffies, timeout));
-+
-+	return -ETIMEDOUT;
-+}
-+
-+static int mtk_i2c_wait_rx_done(struct mtk_i2c *i2c)
-+{
-+	int ret;
-+
-+	ret = poll_up_timeout(i2c->base + REG_SM0ST, I2C_DATARDY);
-+	if (ret < 0)
-+		dev_dbg(i2c->dev, "rx err(%d)\n", ret);
-+
-+	return ret;
-+}
-+
-+static int mtk_i2c_wait_tx_done(struct mtk_i2c *i2c)
-+{
-+	int ret;
-+
-+	ret = poll_up_timeout(i2c->base + REG_SM0ST, I2C_SDOEMPTY);
-+	if (ret < 0)
-+		dev_dbg(i2c->dev, "tx err(%d)\n", ret);
 +
 +	return ret;
 +}
 +
 +static void mtk_i2c_reset(struct mtk_i2c *i2c)
 +{
-+	u32 reg;
-+	device_reset(i2c->adap.dev.parent);
-+	barrier();
++	int ret;
 +
-+	/* ctrl0 */
-+	reg = ODRAIN_HIGH_SM0 | VSYNC_PULSE | (i2c->clk_div << CLK_DIV_SHIFT) |
-+		WAIT_HIGH | SM0_EN;
-+	mtk_i2c_w32(i2c, reg, REG_SM0CTL0);
++	ret = device_reset(i2c->adap.dev.parent);
++	if (ret)
++		dev_err(i2c->dev, "I2C reset failed!\n");
 +
-+	/* auto mode */
-+	mtk_i2c_w32(i2c, AUTOMODE_EN, REG_SM0CFG2);
++	/*
++	 * Don't set SM0CTL0_ODRAIN as its bit meaning is inverted. To
++	 * configure open-drain mode, this bit needs to be cleared.
++	 */
++	iowrite32(((i2c->clk_div << 16) & SM0CTL0_CLK_DIV_MASK) | SM0CTL0_EN |
++		  SM0CTL0_SCL_STRETCH, i2c->base + REG_SM0CTL0_REG);
++	iowrite32(0, i2c->base + REG_SM0CFG2_REG);
 +}
 +
 +static void mtk_i2c_dump_reg(struct mtk_i2c *i2c)
 +{
-+	dev_dbg(i2c->dev, "cfg0 %08x, dout %08x, din %08x, " \
-+			"status %08x, auto %08x, cfg1 %08x, " \
-+			"cfg2 %08x, ctl0 %08x, ctl1 %08x\n",
-+			mtk_i2c_r32(i2c, REG_SM0CFG0),
-+			mtk_i2c_r32(i2c, REG_SM0DOUT),
-+			mtk_i2c_r32(i2c, REG_SM0DIN),
-+			mtk_i2c_r32(i2c, REG_SM0ST),
-+			mtk_i2c_r32(i2c, REG_SM0AUTO),
-+			mtk_i2c_r32(i2c, REG_SM0CFG1),
-+			mtk_i2c_r32(i2c, REG_SM0CFG2),
-+			mtk_i2c_r32(i2c, REG_SM0CTL0),
-+			mtk_i2c_r32(i2c, REG_SM0CTL1));
++	dev_dbg(i2c->dev,
++		"SM0CFG2 %08x, SM0CTL0 %08x, SM0CTL1 %08x, SM0D0 %08x, SM0D1 %08x\n",
++		ioread32(i2c->base + REG_SM0CFG2_REG),
++		ioread32(i2c->base + REG_SM0CTL0_REG),
++		ioread32(i2c->base + REG_SM0CTL1_REG),
++		ioread32(i2c->base + REG_SM0D0_REG),
++		ioread32(i2c->base + REG_SM0D1_REG));
++}
++
++static int mtk_i2c_check_ack(struct mtk_i2c *i2c, u32 expected)
++{
++	u32 ack = readl_relaxed(i2c->base + REG_SM0CTL1_REG);
++	u32 ack_expected = (expected << 16) & SM0CTL1_ACK_MASK;
++
++	return ((ack & ack_expected) == ack_expected) ? 0 : -ENXIO;
++}
++
++static int mtk_i2c_master_start(struct mtk_i2c *i2c)
++{
++	iowrite32(SM0CTL1_START | SM0CTL1_TRI, i2c->base + REG_SM0CTL1_REG);
++	return mtk_i2c_wait_idle(i2c);
++}
++
++static int mtk_i2c_master_stop(struct mtk_i2c *i2c)
++{
++	iowrite32(SM0CTL1_STOP | SM0CTL1_TRI, i2c->base + REG_SM0CTL1_REG);
++	return mtk_i2c_wait_idle(i2c);
++}
++
++static int mtk_i2c_master_cmd(struct mtk_i2c *i2c, u32 cmd, int page_len)
++{
++	iowrite32(cmd | SM0CTL1_TRI | SM0CTL1_PGLEN(page_len),
++		  i2c->base + REG_SM0CTL1_REG);
++	return mtk_i2c_wait_idle(i2c);
 +}
 +
 +static int mtk_i2c_master_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
-+		int num)
++			       int num)
 +{
 +	struct mtk_i2c *i2c;
 +	struct i2c_msg *pmsg;
-+	int i, j, ret;
++	u16 addr;
++	int i, j, ret, len, page_len;
 +	u32 cmd;
++	u32 data[2];
 +
 +	i2c = i2c_get_adapdata(adap);
 +
 +	for (i = 0; i < num; i++) {
 +		pmsg = &msgs[i];
-+		cmd = 0;
-+
-+		dev_dbg(i2c->dev, "addr: 0x%x, len: %d, flags: 0x%x\n",
-+				pmsg->addr, pmsg->len, pmsg->flags);
 +
 +		/* wait hardware idle */
-+		if ((ret = mtk_i2c_wait_idle(i2c)))
++		ret = mtk_i2c_wait_idle(i2c);
++		if (ret)
 +			goto err_timeout;
 +
++		/* start sequence */
++		ret = mtk_i2c_master_start(i2c);
++		if (ret)
++			goto err_timeout;
++
++		/* write address */
 +		if (pmsg->flags & I2C_M_TEN) {
-+			dev_dbg(i2c->dev, "10 bits addr not supported\n");
-+			return -EINVAL;
++			/* 10 bits address */
++			addr = 0xf0 | ((pmsg->addr >> 7) & 0x06);
++			addr |= (pmsg->addr & 0xff) << 8;
++			if (pmsg->flags & I2C_M_RD)
++				addr |= 1;
++			iowrite32(addr, i2c->base + REG_SM0D0_REG);
++			ret = mtk_i2c_master_cmd(i2c, SM0CTL1_WRITE, 2);
++			if (ret)
++				goto err_timeout;
 +		} else {
 +			/* 7 bits address */
-+			mtk_i2c_w32(i2c, pmsg->addr & I2C_DEVADDR_MASK,
-+					REG_SM0CFG0);
++			addr = i2c_8bit_addr_from_msg(pmsg);
++			iowrite32(addr, i2c->base + REG_SM0D0_REG);
++			ret = mtk_i2c_master_cmd(i2c, SM0CTL1_WRITE, 1);
++			if (ret)
++				goto err_timeout;
 +		}
 +
-+		/* buffer length */
-+		if (pmsg->len == 0) {
-+			dev_dbg(i2c->dev, "length is 0\n");
-+			return -EINVAL;
-+		} else
-+			mtk_i2c_w32(i2c, SET_BYTECNT(pmsg->len),
-+					REG_SM0CFG1);
++		/* check address ACK */
++		if (!(pmsg->flags & I2C_M_IGNORE_NAK)) {
++			ret = mtk_i2c_check_ack(i2c, BIT(0));
++			if (ret)
++				goto err_ack;
++		}
 +
-+		j = 0;
-+		if (pmsg->flags & I2C_M_RD) {
-+			cmd |= READ_CMD;
-+			/* start transfer */
-+			barrier();
-+			mtk_i2c_w32(i2c, cmd, REG_SM0AUTO);
-+			do {
-+				/* wait */
-+				if ((ret = mtk_i2c_wait_rx_done(i2c)))
-+					goto err_timeout;
-+				/* read data */
-+				if (pmsg->len)
-+					pmsg->buf[j] = mtk_i2c_r32(i2c,
-+							REG_SM0DIN);
-+				j++;
-+			} while (j < pmsg->len);
-+		} else {
-+			do {
-+				/* write data */
-+				if (pmsg->len)
-+					mtk_i2c_w32(i2c, pmsg->buf[j],
-+							REG_SM0DOUT);
-+				/* start transfer */
-+				if (j == 0) {
-+					barrier();
-+					mtk_i2c_w32(i2c, cmd, REG_SM0AUTO);
++		/* transfer data */
++		for (len = pmsg->len, j = 0; len > 0; len -= 8, j += 8) {
++			page_len = (len >= 8) ? 8 : len;
++
++			if (pmsg->flags & I2C_M_RD) {
++				cmd = (len > 8) ?
++					SM0CTL1_READ : SM0CTL1_READ_LAST;
++			} else {
++				memcpy(data, &pmsg->buf[j], page_len);
++				iowrite32(data[0], i2c->base + REG_SM0D0_REG);
++				iowrite32(data[1], i2c->base + REG_SM0D1_REG);
++				cmd = SM0CTL1_WRITE;
++			}
++
++			ret = mtk_i2c_master_cmd(i2c, cmd, page_len);
++			if (ret)
++				goto err_timeout;
++
++			if (pmsg->flags & I2C_M_RD) {
++				data[0] = ioread32(i2c->base + REG_SM0D0_REG);
++				data[1] = ioread32(i2c->base + REG_SM0D1_REG);
++				memcpy(&pmsg->buf[j], data, page_len);
++			} else {
++				if (!(pmsg->flags & I2C_M_IGNORE_NAK)) {
++					ret = mtk_i2c_check_ack(i2c,
++								(1 << page_len)
++								- 1);
++					if (ret)
++						goto err_ack;
 +				}
-+				/* wait */
-+				if ((ret = mtk_i2c_wait_tx_done(i2c)))
-+					goto err_timeout;
-+				j++;
-+			} while (j < pmsg->len);
++			}
 +		}
 +	}
-+	/* the return value is number of executed messages */
-+	ret = i;
 +
-+	return ret;
++	ret = mtk_i2c_master_stop(i2c);
++	if (ret)
++		goto err_timeout;
++
++	/* the return value is number of executed messages */
++	return i;
++
++err_ack:
++	ret = mtk_i2c_master_stop(i2c);
++	if (ret)
++		goto err_timeout;
++	return -ENXIO;
 +
 +err_timeout:
 +	mtk_i2c_dump_reg(i2c);
@@ -340,7 +296,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +
 +static u32 mtk_i2c_func(struct i2c_adapter *a)
 +{
-+	return I2C_FUNC_I2C | I2C_FUNC_SMBUS_EMUL;
++	return I2C_FUNC_I2C | I2C_FUNC_SMBUS_EMUL | I2C_FUNC_PROTOCOL_MANGLING;
 +}
 +
 +static const struct i2c_algorithm mtk_i2c_algo = {
@@ -355,16 +311,13 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +
 +MODULE_DEVICE_TABLE(of, i2c_mtk_dt_ids);
 +
-+static struct i2c_adapter_quirks mtk_i2c_quirks = {
-+        .max_write_len = BYTECNT_MAX,
-+        .max_read_len = BYTECNT_MAX,
-+};
-+
 +static void mtk_i2c_init(struct mtk_i2c *i2c)
 +{
-+	i2c->clk_div = clk_get_rate(i2c->clk) / i2c->cur_clk;
-+	if (i2c->clk_div > CLK_DIV_MASK)
-+		i2c->clk_div = CLK_DIV_MASK;
++	i2c->clk_div = clk_get_rate(i2c->clk) / i2c->bus_freq - 1;
++	if (i2c->clk_div < 99)
++		i2c->clk_div = 99;
++	if (i2c->clk_div > SM0CTL0_CLK_DIV_MAX)
++		i2c->clk_div = SM0CTL0_CLK_DIV_MAX;
 +
 +	mtk_i2c_reset(i2c);
 +}
@@ -374,22 +327,13 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	struct resource *res;
 +	struct mtk_i2c *i2c;
 +	struct i2c_adapter *adap;
-+	const struct of_device_id *match;
 +	int ret;
 +
-+	match = of_match_device(i2c_mtk_dt_ids, &pdev->dev);
-+
 +	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-+	if (!res) {
-+		dev_err(&pdev->dev, "no memory resource found\n");
-+		return -ENODEV;
-+	}
 +
 +	i2c = devm_kzalloc(&pdev->dev, sizeof(struct mtk_i2c), GFP_KERNEL);
-+	if (!i2c) {
-+		dev_err(&pdev->dev, "failed to allocate i2c_adapter\n");
++	if (!i2c)
 +		return -ENOMEM;
-+	}
 +
 +	i2c->base = devm_ioremap_resource(&pdev->dev, res);
 +	if (IS_ERR(i2c->base))
@@ -398,39 +342,49 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	i2c->clk = devm_clk_get(&pdev->dev, NULL);
 +	if (IS_ERR(i2c->clk)) {
 +		dev_err(&pdev->dev, "no clock defined\n");
-+		return -ENODEV;
++		return PTR_ERR(i2c->clk);
 +	}
-+	clk_prepare_enable(i2c->clk);
++	ret = clk_prepare_enable(i2c->clk);
++	if (ret) {
++		dev_err(&pdev->dev, "Unable to enable clock\n");
++		return ret;
++	}
++
 +	i2c->dev = &pdev->dev;
 +
-+	if (of_property_read_u32(pdev->dev.of_node,
-+				"clock-frequency", &i2c->cur_clk))
-+		i2c->cur_clk = 100000;
++	if (of_property_read_u32(pdev->dev.of_node, "clock-frequency",
++				 &i2c->bus_freq))
++		i2c->bus_freq = I2C_MAX_STANDARD_MODE_FREQ;
++
++	if (i2c->bus_freq == 0) {
++		dev_warn(i2c->dev, "clock-frequency 0 not supported\n");
++		ret = -EINVAL;
++		goto err_disable_clk;
++	}
 +
 +	adap = &i2c->adap;
 +	adap->owner = THIS_MODULE;
-+	adap->class = I2C_CLASS_HWMON | I2C_CLASS_SPD;
 +	adap->algo = &mtk_i2c_algo;
 +	adap->retries = 3;
 +	adap->dev.parent = &pdev->dev;
 +	i2c_set_adapdata(adap, i2c);
 +	adap->dev.of_node = pdev->dev.of_node;
 +	strlcpy(adap->name, dev_name(&pdev->dev), sizeof(adap->name));
-+	adap->quirks = &mtk_i2c_quirks;
 +
 +	platform_set_drvdata(pdev, i2c);
 +
 +	mtk_i2c_init(i2c);
 +
 +	ret = i2c_add_adapter(adap);
-+	if (ret < 0) {
-+		dev_err(&pdev->dev, "failed to add adapter\n");
-+		clk_disable_unprepare(i2c->clk);
-+		return ret;
-+	}
++	if (ret < 0)
++		goto err_disable_clk;
 +
-+	dev_info(&pdev->dev, "clock %uKHz, re-start not support\n",
-+			i2c->cur_clk/1000);
++	dev_info(&pdev->dev, "clock %u kHz\n", i2c->bus_freq / 1000);
++
++	return 0;
++
++err_disable_clk:
++	clk_disable_unprepare(i2c->clk);
 +
 +	return ret;
 +}
@@ -439,8 +393,8 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +{
 +	struct mtk_i2c *i2c = platform_get_drvdata(pdev);
 +
-+	i2c_del_adapter(&i2c->adap);
 +	clk_disable_unprepare(i2c->clk);
++	i2c_del_adapter(&i2c->adap);
 +
 +	return 0;
 +}
@@ -449,25 +403,17 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	.probe		= mtk_i2c_probe,
 +	.remove		= mtk_i2c_remove,
 +	.driver		= {
-+		.owner	= THIS_MODULE,
 +		.name	= "i2c-mt7621",
 +		.of_match_table = i2c_mtk_dt_ids,
 +	},
 +};
 +
-+static int __init i2c_mtk_init (void)
-+{
-+	return platform_driver_register(&mtk_i2c_driver);
-+}
-+subsys_initcall(i2c_mtk_init);
++module_platform_driver(mtk_i2c_driver);
 +
-+static void __exit i2c_mtk_exit (void)
-+{
-+	platform_driver_unregister(&mtk_i2c_driver);
-+}
-+module_exit(i2c_mtk_exit);
-+
-+MODULE_AUTHOR("Steven Liu <steven_liu@mediatek.com>");
-+MODULE_DESCRIPTION("MT7621 I2c host driver");
-+MODULE_LICENSE("GPL");
++MODULE_AUTHOR("Steven Liu");
++MODULE_DESCRIPTION("MT7621 I2C host driver");
++MODULE_LICENSE("GPL v2");
 +MODULE_ALIAS("platform:MT7621-I2C");
+-- 
+2.39.1
+


### PR DESCRIPTION
- Added latest i2c patch https://github.com/Vonger/vocore2/blob/master/openwrt.1907/0045-i2c-add-mt7621-driver.patch
- Updated it to apply without errors (there was a simple error in applying for /drivers/i2c/busses/Makefile)
