### PR TITLE
remove extra packages to speed up boot

### DIFF
--- a/insp_config
+++ b/insp_config
@@ -608,7 +608,7 @@ CONFIG_BUSYBOX_DEFAULT_MKTEMP=y
 CONFIG_BUSYBOX_DEFAULT_MV=y
 CONFIG_BUSYBOX_DEFAULT_NICE=y
 # CONFIG_BUSYBOX_DEFAULT_NL is not set
-CONFIG_BUSYBOX_DEFAULT_NOHUP=y
+# CONFIG_BUSYBOX_DEFAULT_NOHUP is not set
 # CONFIG_BUSYBOX_DEFAULT_NPROC is not set
 # CONFIG_BUSYBOX_DEFAULT_OD is not set
 # CONFIG_BUSYBOX_DEFAULT_PASTE is not set
@@ -2831,7 +2831,7 @@ CONFIG_PACKAGE_kmod-ipt-nat=y
 # CONFIG_PACKAGE_kmod-ipt-nathelper-rtsp is not set
 # CONFIG_PACKAGE_kmod-ipt-nflog is not set
 # CONFIG_PACKAGE_kmod-ipt-nfqueue is not set
-CONFIG_PACKAGE_kmod-ipt-offload=y
+# CONFIG_PACKAGE_kmod-ipt-offload is not set
 # CONFIG_PACKAGE_kmod-ipt-physdev is not set
 # CONFIG_PACKAGE_kmod-ipt-psd is not set
 # CONFIG_PACKAGE_kmod-ipt-quota2 is not set
@@ -2846,9 +2846,9 @@ CONFIG_PACKAGE_kmod-ipt-offload=y
 # CONFIG_PACKAGE_kmod-netatop is not set
 CONFIG_PACKAGE_kmod-nf-conntrack=y
 # CONFIG_PACKAGE_kmod-nf-conntrack-netlink is not set
-CONFIG_PACKAGE_kmod-nf-flow=y
+# CONFIG_PACKAGE_kmod-nf-flow is not set
 CONFIG_PACKAGE_kmod-nf-ipt=y
-CONFIG_PACKAGE_kmod-nf-ipt6=y
+# CONFIG_PACKAGE_kmod-nf-ipt6 is not set
 CONFIG_PACKAGE_kmod-nf-nat=y
 # CONFIG_PACKAGE_kmod-nf-nathelper is not set
 # CONFIG_PACKAGE_kmod-nf-nathelper-extra is not set
@@ -3124,7 +3124,7 @@ CONFIG_PACKAGE_kmod-backlight-pwm=y
 # CONFIG_PACKAGE_kmod-fb-tft is not set
 # CONFIG_PACKAGE_kmod-fb-tft-ili9486 is not set
 CONFIG_PACKAGE_kmod-video-core=y
-CONFIG_PACKAGE_kmod-video-cpia2=y
+# CONFIG_PACKAGE_kmod-video-cpia2 is not set
 CONFIG_PACKAGE_kmod-video-gspca-core=y
 # CONFIG_PACKAGE_kmod-video-gspca-conex is not set
 # CONFIG_PACKAGE_kmod-video-gspca-etoms is not set
@@ -3159,7 +3159,7 @@ CONFIG_PACKAGE_kmod-video-gspca-sunplus=y
 # CONFIG_PACKAGE_kmod-video-gspca-tv8532 is not set
 # CONFIG_PACKAGE_kmod-video-gspca-vc032x is not set
 # CONFIG_PACKAGE_kmod-video-gspca-zc3xx is not set
-CONFIG_PACKAGE_kmod-video-pwc=y
+# CONFIG_PACKAGE_kmod-video-pwc is not set
 CONFIG_PACKAGE_kmod-video-uvc=y
 CONFIG_PACKAGE_kmod-video-videobuf2=y
 
@@ -3890,7 +3890,7 @@ CONFIG_PACKAGE_libattr=y
 #
 # CONFIG_PACKAGE_libfko is not set
 CONFIG_PACKAGE_libip4tc=y
-CONFIG_PACKAGE_libip6tc=y
+# CONFIG_PACKAGE_libip6tc is not set
 # CONFIG_PACKAGE_libiptc is not set
 CONFIG_PACKAGE_libxtables=y
 # CONFIG_PACKAGE_libxtables-nft is not set
@@ -4604,7 +4604,7 @@ CONFIG_PACKAGE_libxtables=y
 # CONFIG_PACKAGE_qt5-concurrent is not set
 CONFIG_PACKAGE_qt5-core=y
 CONFIG_PACKAGE_qt5-network=y
-CONFIG_PACKAGE_qt5-sql=y
+# CONFIG_PACKAGE_qt5-sql is not set
 # CONFIG_PACKAGE_qt5-test is not set
 # CONFIG_PACKAGE_qt5-widgets is not set
 # CONFIG_PACKAGE_qt5-xml is not set
@@ -4912,9 +4912,9 @@ CONFIG_PACKAGE_libjson-c=y
 # CONFIG_PACKAGE_libmms is not set
 # CONFIG_PACKAGE_libmnl is not set
 # CONFIG_PACKAGE_libmodbus is not set
-# CONFIG_PACKAGE_libmosquitto-nossl is not set
-CONFIG_PACKAGE_libmosquitto-ssl=y
-CONFIG_PACKAGE_libmosquittopp=y
+CONFIG_PACKAGE_libmosquitto-nossl=y
+# CONFIG_PACKAGE_libmosquitto-ssl is not set
+# CONFIG_PACKAGE_libmosquittopp is not set
 # CONFIG_PACKAGE_libmount is not set
 # CONFIG_PACKAGE_libmpdclient is not set
 CONFIG_PACKAGE_libmpeg2=y
@@ -5151,8 +5151,8 @@ CONFIG_PACKAGE_zlib=y
 #
 # CONFIG_PACKAGE_luci-base is not set
 # CONFIG_LUCI_SRCDIET is not set
-CONFIG_LUCI_JSMIN=y
-CONFIG_LUCI_CSSTIDY=y
+# CONFIG_LUCI_JSMIN is not set
+# CONFIG_LUCI_CSSTIDY is not set
 
 #
 # Translations
@@ -5190,7 +5190,6 @@ CONFIG_LUCI_CSSTIDY=y
 # CONFIG_PACKAGE_luci-mod-admin-full is not set
 # CONFIG_PACKAGE_luci-mod-failsafe is not set
 # CONFIG_PACKAGE_luci-mod-freifunk is not set
-# CONFIG_PACKAGE_luci-mod-freifunk-community is not set
 # CONFIG_PACKAGE_luci-mod-network is not set
 # CONFIG_PACKAGE_luci-mod-rpc is not set
 # CONFIG_PACKAGE_luci-mod-status is not set
@@ -5249,7 +5248,6 @@ CONFIG_LUCI_CSSTIDY=y
 # CONFIG_PACKAGE_luci-app-radicale is not set
 # CONFIG_PACKAGE_luci-app-radicale2 is not set
 # CONFIG_PACKAGE_luci-app-rosy-file-server is not set
-# CONFIG_PACKAGE_luci-app-rp-pppoe-server is not set
 # CONFIG_PACKAGE_luci-app-samba is not set
 # CONFIG_PACKAGE_luci-app-samba4 is not set
 # CONFIG_PACKAGE_luci-app-shadowsocks-libev is not set
@@ -5257,7 +5255,6 @@ CONFIG_LUCI_CSSTIDY=y
 # CONFIG_PACKAGE_luci-app-siitwizard is not set
 # CONFIG_PACKAGE_luci-app-simple-adblock is not set
 # CONFIG_PACKAGE_luci-app-snmpd is not set
-# CONFIG_PACKAGE_luci-app-splash is not set
 # CONFIG_PACKAGE_luci-app-sqm is not set
 # CONFIG_PACKAGE_luci-app-squid is not set
 # CONFIG_PACKAGE_luci-app-statistics is not set
@@ -5462,9 +5459,9 @@ CONFIG_PACKAGE_gst1-mod-jpegformat=y
 # CONFIG_PACKAGE_gst1-mod-lame is not set
 # CONFIG_PACKAGE_gst1-mod-legacyrawparse is not set
 # CONFIG_PACKAGE_gst1-mod-level is not set
-CONFIG_PACKAGE_gst1-mod-matroska=y
+# CONFIG_PACKAGE_gst1-mod-matroska is not set
 # CONFIG_PACKAGE_gst1-mod-midi is not set
-CONFIG_PACKAGE_gst1-mod-mpeg2dec=y
+# CONFIG_PACKAGE_gst1-mod-mpeg2dec is not set
 # CONFIG_PACKAGE_gst1-mod-mpegpsdemux is not set
 # CONFIG_PACKAGE_gst1-mod-mpegpsmux is not set
 # CONFIG_PACKAGE_gst1-mod-mpg123 is not set
@@ -5490,7 +5487,7 @@ CONFIG_PACKAGE_gst1-mod-playback=y
 CONFIG_PACKAGE_gst1-mod-rtp=y
 # CONFIG_PACKAGE_gst1-mod-rtpmanager is not set
 # CONFIG_PACKAGE_gst1-mod-rtponvif is not set
-CONFIG_PACKAGE_gst1-mod-rtsp=y
+# CONFIG_PACKAGE_gst1-mod-rtsp is not set
 # CONFIG_PACKAGE_gst1-mod-sbc is not set
 # CONFIG_PACKAGE_gst1-mod-sdpelem is not set
 # CONFIG_PACKAGE_gst1-mod-segmentclip is not set
@@ -5514,11 +5511,11 @@ CONFIG_PACKAGE_gst1-mod-udp=y
 CONFIG_PACKAGE_gst1-mod-video4linux2=y
 # CONFIG_PACKAGE_gst1-mod-videobox is not set
 CONFIG_PACKAGE_gst1-mod-videoconvert=y
-CONFIG_PACKAGE_gst1-mod-videocrop=y
-CONFIG_PACKAGE_gst1-mod-videofilter=y
+# CONFIG_PACKAGE_gst1-mod-videocrop is not set
+# CONFIG_PACKAGE_gst1-mod-videofilter is not set
 # CONFIG_PACKAGE_gst1-mod-videofiltersbad is not set
 # CONFIG_PACKAGE_gst1-mod-videoframe_audiolevel is not set
-CONFIG_PACKAGE_gst1-mod-videomixer=y
+# CONFIG_PACKAGE_gst1-mod-videomixer is not set
 CONFIG_PACKAGE_gst1-mod-videorate=y
 CONFIG_PACKAGE_gst1-mod-videoscale=y
 # CONFIG_PACKAGE_gst1-mod-videosignal is not set
@@ -5645,16 +5642,11 @@ CONFIG_PACKAGE_gstreamer1-utils=y
 #
 # Captive Portals
 #
-# CONFIG_PACKAGE_apfree-wifidog is not set
 # CONFIG_PACKAGE_coova-chilli is not set
-# CONFIG_PACKAGE_nodogsplash is not set
-# CONFIG_PACKAGE_opennds is not set
-# CONFIG_PACKAGE_wifidog is not set
 # CONFIG_PACKAGE_wifidog-ng-mbedtls is not set
 # CONFIG_PACKAGE_wifidog-ng-nossl is not set
 # CONFIG_PACKAGE_wifidog-ng-openssl is not set
 # CONFIG_PACKAGE_wifidog-ng-wolfssl is not set
-# CONFIG_PACKAGE_wifidog-tls is not set
 
 #
 # Download Manager
@@ -5703,52 +5695,9 @@ CONFIG_PACKAGE_gstreamer1-utils=y
 # CONFIG_PACKAGE_ebtables is not set
 # CONFIG_PACKAGE_fwknop is not set
 # CONFIG_PACKAGE_fwknopd is not set
-CONFIG_PACKAGE_iptables=y
+# CONFIG_PACKAGE_iptables is not set
 # CONFIG_IPTABLES_CONNLABEL is not set
 # CONFIG_IPTABLES_NFTABLES is not set
-# CONFIG_PACKAGE_iptables-mod-account is not set
-# CONFIG_PACKAGE_iptables-mod-chaos is not set
-# CONFIG_PACKAGE_iptables-mod-checksum is not set
-# CONFIG_PACKAGE_iptables-mod-cluster is not set
-# CONFIG_PACKAGE_iptables-mod-clusterip is not set
-# CONFIG_PACKAGE_iptables-mod-condition is not set
-# CONFIG_PACKAGE_iptables-mod-conntrack-extra is not set
-# CONFIG_PACKAGE_iptables-mod-delude is not set
-# CONFIG_PACKAGE_iptables-mod-dhcpmac is not set
-# CONFIG_PACKAGE_iptables-mod-dnetmap is not set
-# CONFIG_PACKAGE_iptables-mod-extra is not set
-# CONFIG_PACKAGE_iptables-mod-filter is not set
-# CONFIG_PACKAGE_iptables-mod-fuzzy is not set
-# CONFIG_PACKAGE_iptables-mod-geoip is not set
-# CONFIG_PACKAGE_iptables-mod-hashlimit is not set
-# CONFIG_PACKAGE_iptables-mod-iface is not set
-# CONFIG_PACKAGE_iptables-mod-ipmark is not set
-# CONFIG_PACKAGE_iptables-mod-ipopt is not set
-# CONFIG_PACKAGE_iptables-mod-ipp2p is not set
-# CONFIG_PACKAGE_iptables-mod-iprange is not set
-# CONFIG_PACKAGE_iptables-mod-ipsec is not set
-# CONFIG_PACKAGE_iptables-mod-ipv4options is not set
-# CONFIG_PACKAGE_iptables-mod-led is not set
-# CONFIG_PACKAGE_iptables-mod-length2 is not set
-# CONFIG_PACKAGE_iptables-mod-logmark is not set
-# CONFIG_PACKAGE_iptables-mod-lscan is not set
-# CONFIG_PACKAGE_iptables-mod-lua is not set
-# CONFIG_PACKAGE_iptables-mod-nat-extra is not set
-# CONFIG_PACKAGE_iptables-mod-nflog is not set
-# CONFIG_PACKAGE_iptables-mod-nfqueue is not set
-# CONFIG_PACKAGE_iptables-mod-physdev is not set
-# CONFIG_PACKAGE_iptables-mod-psd is not set
-# CONFIG_PACKAGE_iptables-mod-quota2 is not set
-# CONFIG_PACKAGE_iptables-mod-rpfilter is not set
-# CONFIG_PACKAGE_iptables-mod-sysrq is not set
-# CONFIG_PACKAGE_iptables-mod-tarpit is not set
-# CONFIG_PACKAGE_iptables-mod-tee is not set
-# CONFIG_PACKAGE_iptables-mod-tproxy is not set
-# CONFIG_PACKAGE_iptables-mod-trace is not set
-# CONFIG_PACKAGE_iptables-mod-u32 is not set
-# CONFIG_PACKAGE_iptables-mod-ulog is not set
-# CONFIG_PACKAGE_iptaccount is not set
-# CONFIG_PACKAGE_iptgeoip is not set
 # CONFIG_PACKAGE_miniupnpc is not set
 # CONFIG_PACKAGE_miniupnpd is not set
 # CONFIG_PACKAGE_natpmpc is not set
@@ -5792,7 +5741,6 @@ CONFIG_PACKAGE_iptables=y
 # CONFIG_PACKAGE_bind-rndc is not set
 # CONFIG_PACKAGE_bind-server is not set
 # CONFIG_PACKAGE_bind-tools is not set
-# CONFIG_PACKAGE_danish is not set
 # CONFIG_PACKAGE_ddns-scripts is not set
 # CONFIG_PACKAGE_dhcp-forwarder is not set
 # CONFIG_PACKAGE_dnscrypt-proxy is not set
@@ -5941,7 +5889,7 @@ CONFIG_DNSDIST_OPENSSL=y
 # OpenLDAP
 #
 # CONFIG_PACKAGE_libopenldap is not set
-CONFIG_OPENLDAP_DEBUG=y
+# CONFIG_OPENLDAP_DEBUG is not set
 # CONFIG_OPENLDAP_CRYPT is not set
 # CONFIG_OPENLDAP_MONITOR is not set
 # CONFIG_OPENLDAP_DB47 is not set
@@ -6107,7 +6055,6 @@ CONFIG_OPENLDAP_DEBUG=y
 # CONFIG_PACKAGE_chaosvpn is not set
 # CONFIG_PACKAGE_fastd is not set
 # CONFIG_PACKAGE_ipsec-tools is not set
-# CONFIG_PACKAGE_libreswan is not set
 # CONFIG_PACKAGE_ocserv is not set
 # CONFIG_PACKAGE_openconnect is not set
 # CONFIG_PACKAGE_opennhrp is not set
@@ -6124,7 +6071,6 @@ CONFIG_OPENLDAP_DEBUG=y
 # CONFIG_PACKAGE_softethervpn5-client is not set
 # CONFIG_PACKAGE_softethervpn5-server is not set
 # CONFIG_PACKAGE_sstp-client is not set
-# CONFIG_PACKAGE_strongswan is not set
 # CONFIG_PACKAGE_tinc is not set
 # CONFIG_PACKAGE_uanytun is not set
 # CONFIG_PACKAGE_uanytun-nettle is not set
@@ -6134,7 +6080,6 @@ CONFIG_OPENLDAP_DEBUG=y
 # CONFIG_PACKAGE_vpnc-scripts is not set
 # CONFIG_PACKAGE_wireguard is not set
 # CONFIG_PACKAGE_wireguard-tools is not set
-# CONFIG_PACKAGE_xl2tpd is not set
 # CONFIG_PACKAGE_zerotier is not set
 
 #
@@ -6182,7 +6127,6 @@ CONFIG_OPENLDAP_DEBUG=y
 # CONFIG_PACKAGE_shadowsocks-libev-config is not set
 # CONFIG_PACKAGE_shadowsocks-libev-ss-local is not set
 # CONFIG_PACKAGE_shadowsocks-libev-ss-redir is not set
-# CONFIG_PACKAGE_shadowsocks-libev-ss-rules is not set
 # CONFIG_PACKAGE_shadowsocks-libev-ss-server is not set
 # CONFIG_PACKAGE_shadowsocks-libev-ss-tunnel is not set
 # CONFIG_PACKAGE_sockd is not set
@@ -6200,11 +6144,57 @@ CONFIG_OPENLDAP_DEBUG=y
 # CONFIG_PACKAGE_hcxtools is not set
 
 #
+# WirelessAPD
+#
+# CONFIG_PACKAGE_eapol-test is not set
+# CONFIG_PACKAGE_eapol-test-mbedtls is not set
+# CONFIG_PACKAGE_eapol-test-openssl is not set
+# CONFIG_PACKAGE_eapol-test-wolfssl is not set
+# CONFIG_PACKAGE_hostapd is not set
+# CONFIG_PACKAGE_hostapd-basic is not set
+# CONFIG_PACKAGE_hostapd-basic-mbedtls is not set
+# CONFIG_PACKAGE_hostapd-basic-openssl is not set
+# CONFIG_PACKAGE_hostapd-basic-wolfssl is not set
+CONFIG_PACKAGE_hostapd-common=y
+# CONFIG_PACKAGE_hostapd-mbedtls is not set
+# CONFIG_PACKAGE_hostapd-mini is not set
+# CONFIG_PACKAGE_hostapd-openssl is not set
+# CONFIG_PACKAGE_hostapd-utils is not set
+# CONFIG_PACKAGE_hostapd-wolfssl is not set
+# CONFIG_PACKAGE_wpa-cli is not set
+# CONFIG_PACKAGE_wpa-supplicant is not set
+# CONFIG_WPA_RFKILL_SUPPORT is not set
+CONFIG_WPA_MSG_MIN_PRIORITY=3
+# CONFIG_WPA_WOLFSSL is not set
+# CONFIG_DRIVER_WEXT_SUPPORT is not set
+CONFIG_DRIVER_11N_SUPPORT=y
+CONFIG_DRIVER_11AC_SUPPORT=y
+CONFIG_DRIVER_11W_SUPPORT=y
+# CONFIG_PACKAGE_wpa-supplicant-basic is not set
+# CONFIG_PACKAGE_wpa-supplicant-mbedtls is not set
+# CONFIG_PACKAGE_wpa-supplicant-mesh-mbedtls is not set
+# CONFIG_PACKAGE_wpa-supplicant-mesh-openssl is not set
+# CONFIG_PACKAGE_wpa-supplicant-mesh-wolfssl is not set
+# CONFIG_PACKAGE_wpa-supplicant-mini is not set
+# CONFIG_PACKAGE_wpa-supplicant-openssl is not set
+# CONFIG_PACKAGE_wpa-supplicant-p2p is not set
+# CONFIG_PACKAGE_wpa-supplicant-wolfssl is not set
+# CONFIG_PACKAGE_wpad is not set
+CONFIG_PACKAGE_wpad-basic=y
+# CONFIG_PACKAGE_wpad-basic-mbedtls is not set
+# CONFIG_PACKAGE_wpad-basic-openssl is not set
+# CONFIG_PACKAGE_wpad-basic-wolfssl is not set
+# CONFIG_PACKAGE_wpad-mbedtls is not set
+# CONFIG_PACKAGE_wpad-mesh-mbedtls is not set
+# CONFIG_PACKAGE_wpad-mesh-openssl is not set
+# CONFIG_PACKAGE_wpad-mesh-wolfssl is not set
+# CONFIG_PACKAGE_wpad-mini is not set
+# CONFIG_PACKAGE_wpad-openssl is not set
+# CONFIG_PACKAGE_wpad-wolfssl is not set
+
+#
 # dial-in/up
 #
-# CONFIG_PACKAGE_rp-pppoe-common is not set
-# CONFIG_PACKAGE_rp-pppoe-relay is not set
-# CONFIG_PACKAGE_rp-pppoe-server is not set
 
 #
 # tcprelay
@@ -6258,9 +6248,6 @@ CONFIG_OPENLDAP_DEBUG=y
 # CONFIG_PACKAGE_dhcpcd is not set
 # CONFIG_PACKAGE_dmapd is not set
 # CONFIG_PACKAGE_dnscrypt-proxy2 is not set
-# CONFIG_PACKAGE_eapol-test is not set
-# CONFIG_PACKAGE_eapol-test-openssl is not set
-# CONFIG_PACKAGE_eapol-test-wolfssl is not set
 # CONFIG_PACKAGE_esniper is not set
 # CONFIG_PACKAGE_etherwake is not set
 # CONFIG_PACKAGE_ethtool is not set
@@ -6270,13 +6257,6 @@ CONFIG_OPENLDAP_DEBUG=y
 # CONFIG_PACKAGE_geth is not set
 # CONFIG_PACKAGE_gnunet is not set
 # CONFIG_PACKAGE_gre is not set
-# CONFIG_PACKAGE_hostapd is not set
-# CONFIG_PACKAGE_hostapd-basic is not set
-CONFIG_PACKAGE_hostapd-common=y
-# CONFIG_PACKAGE_hostapd-mini is not set
-# CONFIG_PACKAGE_hostapd-openssl is not set
-# CONFIG_PACKAGE_hostapd-utils is not set
-# CONFIG_PACKAGE_hostapd-wolfssl is not set
 # CONFIG_PACKAGE_httping is not set
 # CONFIG_PACKAGE_httping-nossl is not set
 # CONFIG_PACKAGE_https-dns-proxy is not set
@@ -6330,12 +6310,10 @@ CONFIG_PACKAGE_iw=y
 # CONFIG_PACKAGE_mikrotik-btest is not set
 # CONFIG_PACKAGE_mini_snmpd is not set
 # CONFIG_PACKAGE_modemmanager is not set
-# CONFIG_PACKAGE_mosquitto-client-nossl is not set
-CONFIG_PACKAGE_mosquitto-client-ssl=y
-# CONFIG_PACKAGE_mosquitto-nossl is not set
-CONFIG_PACKAGE_mosquitto-ssl=y
-CONFIG_MOSQUITTO_LWS=y
-CONFIG_MOSQUITTO_PASSWD=y
+CONFIG_PACKAGE_mosquitto-client-nossl=y
+# CONFIG_PACKAGE_mosquitto-client-ssl is not set
+CONFIG_PACKAGE_mosquitto-nossl=y
+# CONFIG_PACKAGE_mosquitto-ssl is not set
 # CONFIG_PACKAGE_mtr is not set
 # CONFIG_PACKAGE_nbd is not set
 # CONFIG_PACKAGE_nbd-server is not set
@@ -6361,18 +6339,9 @@ CONFIG_MOSQUITTO_PASSWD=y
 # CONFIG_PACKAGE_phantap is not set
 # CONFIG_PACKAGE_pingcheck is not set
 # CONFIG_PACKAGE_port-mirroring is not set
-CONFIG_PACKAGE_ppp=y
-# CONFIG_PACKAGE_ppp-mod-passwordfd is not set
-# CONFIG_PACKAGE_ppp-mod-pppoa is not set
-CONFIG_PACKAGE_ppp-mod-pppoe=y
-# CONFIG_PACKAGE_ppp-mod-pppol2tp is not set
-# CONFIG_PACKAGE_ppp-mod-pptp is not set
-# CONFIG_PACKAGE_ppp-mod-radius is not set
+# CONFIG_PACKAGE_ppp is not set
 # CONFIG_PACKAGE_ppp-multilink is not set
-# CONFIG_PACKAGE_pppdump is not set
-# CONFIG_PACKAGE_pppoe-discovery is not set
 # CONFIG_PACKAGE_pppossh is not set
-# CONFIG_PACKAGE_pppstats is not set
 # CONFIG_PACKAGE_proto-bonding is not set
 # CONFIG_PACKAGE_ptunnel-ng is not set
 # CONFIG_PACKAGE_radsecproxy is not set
@@ -6440,30 +6409,6 @@ CONFIG_PACKAGE_uclient-fetch=y
 # CONFIG_PACKAGE_vti is not set
 # CONFIG_PACKAGE_vxlan is not set
 # CONFIG_PACKAGE_wakeonlan is not set
-# CONFIG_PACKAGE_wpa-cli is not set
-# CONFIG_PACKAGE_wpa-supplicant is not set
-# CONFIG_WPA_RFKILL_SUPPORT is not set
-CONFIG_WPA_MSG_MIN_PRIORITY=3
-# CONFIG_WPA_WOLFSSL is not set
-# CONFIG_DRIVER_WEXT_SUPPORT is not set
-CONFIG_DRIVER_11N_SUPPORT=y
-CONFIG_DRIVER_11AC_SUPPORT=y
-CONFIG_DRIVER_11W_SUPPORT=y
-# CONFIG_PACKAGE_wpa-supplicant-basic is not set
-# CONFIG_PACKAGE_wpa-supplicant-mesh-openssl is not set
-# CONFIG_PACKAGE_wpa-supplicant-mesh-wolfssl is not set
-# CONFIG_PACKAGE_wpa-supplicant-mini is not set
-# CONFIG_PACKAGE_wpa-supplicant-openssl is not set
-# CONFIG_PACKAGE_wpa-supplicant-p2p is not set
-# CONFIG_PACKAGE_wpa-supplicant-wolfssl is not set
-# CONFIG_PACKAGE_wpad is not set
-CONFIG_PACKAGE_wpad-basic=y
-# CONFIG_PACKAGE_wpad-basic-wolfssl is not set
-# CONFIG_PACKAGE_wpad-mesh-openssl is not set
-# CONFIG_PACKAGE_wpad-mesh-wolfssl is not set
-# CONFIG_PACKAGE_wpad-mini is not set
-# CONFIG_PACKAGE_wpad-openssl is not set
-# CONFIG_PACKAGE_wpad-wolfssl is not set
 # CONFIG_PACKAGE_wpan-tools is not set
 # CONFIG_PACKAGE_wwan is not set
 # CONFIG_PACKAGE_xinetd is not set
@@ -6827,7 +6772,7 @@ CONFIG_PACKAGE_i2c-tools=y
 # CONFIG_PACKAGE_io is not set
 # CONFIG_PACKAGE_irqbalance is not set
 # CONFIG_PACKAGE_iwcap is not set
-CONFIG_PACKAGE_iwinfo=y
+# CONFIG_PACKAGE_iwinfo is not set
 # CONFIG_PACKAGE_jq is not set
 CONFIG_PACKAGE_jshn=y
 # CONFIG_PACKAGE_kmod is not set


### PR DESCRIPTION
- removed extra packages, such as:
   - unused gstreamer packages
   - mosquitto-ssl (replaced with nossl)
   - some kernel modules
- this reduced the images size from 13Mb to 12Mb
- not significantly, but boot time improved by around 1-2sec
- I've done basic testing: connect to BK7000, video streaming, pip, LEDs, buttons. All works OK