### PR TITLE
increase spi freq, remove unsued modules from dts

### DIFF
--- a/target/linux/ramips/dts/VOCORE2.dts
+++ b/target/linux/ramips/dts/VOCORE2.dts
@@ -31,7 +31,7 @@
 	m25p80@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <100000000>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -63,11 +63,6 @@
 			};
 		};
 	};
-};
-
-&sdhci {
-       status = "okay";
-       mediatek,cd-poll;
 };
 
 &i2c {

--- a/target/linux/ramips/dts/VOCORE2.dtsi
+++ b/target/linux/ramips/dts/VOCORE2.dtsi
@@ -27,14 +27,6 @@
 	mediatek,portdisable = <0x3a>;
 };
 
-&i2s {
-	status = "okay";
-};
-
-&gdma {
-	status = "okay";
-};
-
 &pwm {
 	status = "okay";
 };


### PR DESCRIPTION
- increased SPI freq from 10MHz to 100MHz. 
- this speeds up load time a lot. It's now around 32sec till Blue LED is up
- also removed some unused peripherals from dts files
