### PR TITLE
fix led flickering issue

### DIFF
--- a/target/linux/ramips/dts/VOCORE2.dts
+++ b/target/linux/ramips/dts/VOCORE2.dts
@@ -89,3 +89,8 @@
 	label = "INSP_GPIO3";
 	status = "disabled";
 };
+
+&uart2 {
+	label = "INSP_GPIO20";
+	status = "disabled";
+};


### PR DESCRIPTION
Refer OP 17009 for more information. Basically GPIO_20 (LOW_GAIN_LED) was muxed and used as UART2 TX instead by disabling the UART2 fixed the LED flickering issue.

**NOTE:** UART2 was used a boot debug console and with this change the boot console will be displayed for couple of seconds and stops. If need to debug the HDLE application need to ssh to the HDLE.
